### PR TITLE
連打音符の重ね順をTJAP2fPC準拠に変更&2fixed

### DIFF
--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
@@ -352,6 +352,7 @@ namespace DTXMania
             public int nBalloon;
             public int nProcessTime;
             public int nスクロール方向;
+            public int n描画優先度; //(特殊)現状連打との判断目的で使用
             public ENoteState eNoteState;
             public EAVI種別 eAVI種別;
 			public E楽器パート e楽器パート = E楽器パート.UNKNOWN;
@@ -444,7 +445,8 @@ namespace DTXMania
                 this.fBMSCROLLTime = 0;
                 this.nノーツ終了位置 = 0;
                 this.nノーツ終了時刻ms = 0;
-				this.nLag = -999;
+                this.n描画優先度 = 0;
+                this.nLag = -999;
 				this.bIsAutoPlayed = false;
 				this.b演奏終了後も再生が続くチップである = false;
                 this.nList上の位置 = 0;

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CAct演奏DrumsRunner.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CAct演奏DrumsRunner.cs
@@ -38,6 +38,7 @@ namespace DTXMania
                     if(Index >= 128)
                     {
                         Index = 0;
+                        break; // 2018.6.15 IMARER 無限ループが発生するので修正
                     }
                 }
                 if (pChip.nチャンネル番号 < 0x15 || (pChip.nチャンネル番号 >= 0x1A))

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
@@ -1759,7 +1759,7 @@ namespace DTXMania
                                 CDTXMania.Tx.Notes.vc拡大縮小倍率.X = index - 65;
                                 CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x + 65, y, new Rectangle( 780, 0, 1, 130 ) );
                                 CDTXMania.Tx.Notes.vc拡大縮小倍率.X = 1.0f;
-                                //CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 650, num9, 130, 130 ) );
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x末端, y, 0, new Rectangle(910, 0, 130, 130));
                                 CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, 0, new Rectangle( 650, num9, 130, 130 ) );
                             }
 
@@ -1784,6 +1784,7 @@ namespace DTXMania
                                 CDTXMania.Tx.Notes.vc拡大縮小倍率.X = index - 65;
                                 CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x + 65, y, new Rectangle( 1170, 0, 1, 130 ) );
                                 CDTXMania.Tx.Notes.vc拡大縮小倍率.X = 1.0f;
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x末端, y, 0, new Rectangle(1300, num9, 130, 130));
                                 CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 1040, num9, 130, 130 ) );
                             }
 
@@ -1824,8 +1825,8 @@ namespace DTXMania
                             }
                             if( pChip.n連打音符State != 7 )
                             {
-                                if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
-                                    CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( n, num9, 130, 130 ) );//大音符:1170
+                                //if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
+                                //    CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( n, num9, 130, 130 ) );//大音符:1170
                                 CDTXMania.Tx.SenNotes.t2D描画(CDTXMania.app.Device, x + 56, y + nSenotesY, new Rectangle( 58, 270, 78, 30 ) );
                             }
 


### PR DESCRIPTION
Game_Mob_Beat=0の場合CCounterを生成しないよう変更(無限ループ対策)
Runnerのインデックスをリセットする際に無限ループが発生しないよう対策