### PR TITLE
Optimize performance further using very long tja "挑戦! スペック8段"

### DIFF
--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
@@ -1465,25 +1465,26 @@ namespace DTXMania
 						chip.rAVI = null;
                         chip.rDShow = null;
 						chip.rAVIPan = null;
-						if( this.listAVIPAN.ContainsKey( chip.n整数値 ) )
+						if( this.listAVIPAN.TryGetValue( chip.n整数値, out CAVIPAN cavipan ) )
 						{
-							CAVIPAN cavipan = this.listAVIPAN[ chip.n整数値 ];
-							if( this.listAVI.ContainsKey( cavipan.nAVI番号 ) && ( this.listAVI[ cavipan.nAVI番号 ].avi != null ) )
+							if( this.listAVI.TryGetValue( cavipan.nAVI番号, out CAVI cavi ) && ( cavi.avi != null ) )
 							{
 								chip.eAVI種別 = EAVI種別.AVIPAN;
-								chip.rAVI = this.listAVI[ cavipan.nAVI番号 ];
+								chip.rAVI = cavi;
                                 //if( CDTXMania.ConfigIni.bDirectShowMode == true )
                                     chip.rDShow = this.listDS[ cavipan.nAVI番号 ];
 								chip.rAVIPan = cavipan;
 								continue;
 							}
 						}
-						if( this.listAVI.ContainsKey( chip.n整数値 ) && ( this.listAVI[ chip.n整数値 ].avi != null ) || ( this.listDS.ContainsKey( chip.n整数値 ) && ( this.listDS[ chip.n整数値 ].dshow != null ) ) )
+
+                        CDirectShow ds = null;
+                        if( this.listAVI.TryGetValue( chip.n整数値, out CAVI cavi2 ) && ( cavi2.avi != null ) || ( this.listDS.TryGetValue( chip.n整数値, out ds ) && ( ds.dshow != null ) ) )
 						{
 							chip.eAVI種別 = EAVI種別.AVI;
-							chip.rAVI = this.listAVI[ chip.n整数値 ];
+							chip.rAVI = cavi2;
                             //if(CDTXMania.ConfigIni.bDirectShowMode == true)
-                                chip.rDShow = this.listDS[ chip.n整数値 ];
+                                chip.rDShow = ds;
 						}
 					}
 				}
@@ -1527,9 +1528,8 @@ namespace DTXMania
 		}
 		public void tWavの再生停止( int nWaveの内部番号, bool bミキサーからも削除する )
 		{
-			if( this.listWAV.ContainsKey( nWaveの内部番号 ) )
+			if( this.listWAV.TryGetValue( nWaveの内部番号, out CWAV cwav ) )
 			{
-				CWAV cwav = this.listWAV[ nWaveの内部番号 ];
 				for ( int i = 0; i < nPolyphonicSounds; i++ )
 				{
 					if( cwav.rSound[ i ] != null && cwav.rSound[ i ].b再生中 )
@@ -1822,9 +1822,8 @@ namespace DTXMania
 				{
 					throw new ArgumentOutOfRangeException();
 				}
-				if( this.listWAV.ContainsKey( pChip.n整数値_内部番号 ) )
+				if( this.listWAV.TryGetValue( pChip.n整数値_内部番号, out CWAV wc ) )
 				{
-					CWAV wc = this.listWAV[ pChip.n整数値_内部番号 ];
 					int index = wc.n現在再生中のサウンド番号 = ( wc.n現在再生中のサウンド番号 + 1 ) % nPolyphonicSounds;
 					if( ( wc.rSound[ 0 ] != null ) && 
 						( wc.rSound[ 0 ].bストリーム再生する || wc.rSound[index] == null ) )
@@ -2175,10 +2174,9 @@ namespace DTXMania
 						//}
 						foreach ( CChip chip in this.listChip )
 						{
-							if ( this.listWAV.ContainsKey( chip.n整数値_内部番号 ) )
+							if ( this.listWAV.TryGetValue( chip.n整数値_内部番号, out CWAV cwav ) )
 							//foreach ( CWAV cwav in this.listWAV.Values )
 							{
-								CWAV cwav = this.listWAV[ chip.n整数値_内部番号 ];
 								//	if ( chip.n整数値_内部番号 == cwav.n内部番号 )
 								//	{
 								chip.dbチップサイズ倍率 = ( (double) cwav.nチップサイズ ) / 100.0;
@@ -2457,9 +2455,9 @@ namespace DTXMania
                                         if( this.bOFFSETの値がマイナスである == false )
                                             chip.n発声時刻ms += this.nOFFSET;
 										ms = chip.n発声時刻ms;
-										if ( this.listBPM.ContainsKey( chip.n整数値_内部番号 ) )
+										if ( this.listBPM.TryGetValue( chip.n整数値_内部番号, out CBPM cBPM) )
 										{
-											bpm = ( ( this.listBPM[ chip.n整数値_内部番号 ].n表記上の番号 == 0 ) ? 0.0 : this.BASEBPM ) + this.listBPM[ chip.n整数値_内部番号 ].dbBPM値;
+                                            bpm = (cBPM.n表記上の番号 == 0  ? 0.0 : this.BASEBPM ) + cBPM.dbBPM値;
                                             this.dbNowBPM = bpm;
 										}
 										continue;
@@ -2472,10 +2470,10 @@ namespace DTXMania
                                             chip.n発声時刻ms += this.nMOVIEOFFSET;
                                         else
                                             chip.n発声時刻ms -= this.nMOVIEOFFSET;
-										if ( this.listAVIPAN.ContainsKey( chip.n整数値 ) )
+										if ( this.listAVIPAN.TryGetValue( chip.n整数値, out CAVIPAN cavipan) )
 										{
-											int num21 = ms + ( (int) ( ( ( 0x271 * ( chip.n発声位置 - n発声位置 ) ) * this.dbBarLength ) / bpm ) );
-											int num22 = ms + ( (int) ( ( ( 0x271 * ( ( chip.n発声位置 + this.listAVIPAN[ chip.n整数値 ].n移動時間ct ) - n発声位置 ) ) * this.dbBarLength ) / bpm ) );
+                                            int num21 = ms + ( (int) ( ( ( 0x271 * ( chip.n発声位置 - n発声位置 ) ) * this.dbBarLength ) / bpm ) );
+                                            int num22 = ms + ( (int) ( ( ( 0x271 * ( ( chip.n発声位置 + cavipan.n移動時間ct ) - n発声位置 ) ) * this.dbBarLength ) / bpm ) );
 											chip.n総移動時間 = num22 - num21;
 										}
 										continue;
@@ -2560,10 +2558,10 @@ namespace DTXMania
                                     }
                                 case 0x9D:
                                     {
-										if ( this.listSCROLL.ContainsKey( chip.n整数値_内部番号 ) )
-										{
+										//if ( this.listSCROLL.ContainsKey( chip.n整数値_内部番号 ) )
+										//{
                                             //this.dbNowSCROLL = ( ( this.listSCROLL[ chip.n整数値_内部番号 ].n表記上の番号 == 0 ) ? 0.0 : 1.0 ) + this.listSCROLL[ chip.n整数値_内部番号 ].dbSCROLL値;
-										}
+										//}
 
                                         //switch (chip.nコース)
                                         //{
@@ -2608,10 +2606,10 @@ namespace DTXMania
                                     {
                                         if (this.bOFFSETの値がマイナスである)
                                             chip.n発声時刻ms += this.nOFFSET;
-                                        if ( this.listBRANCH.ContainsKey( chip.n整数値_内部番号 ) )
-                                        {
+                                        //if ( this.listBRANCH.ContainsKey( chip.n整数値_内部番号 ) )
+                                        //{
                                             //this.listBRANCH[chip.n整数値_内部番号].db分岐時間ms = chip.n発声時刻ms + ( this.bOFFSETの値がマイナスである ? this.nOFFSET : 0 );
-                                        }
+                                        //}
 
                                         continue;
                                     }
@@ -2682,28 +2680,28 @@ namespace DTXMania
 						#region [ チップの種類を分類し、対応するフラグを立てる ]
 						foreach ( CChip chip in this.listChip )
 						{
-							if ( ( chip.bWAVを使うチャンネルである && this.listWAV.ContainsKey( chip.n整数値_内部番号 ) ) && !this.listWAV[ chip.n整数値_内部番号 ].listこのWAVを使用するチャンネル番号の集合.Contains( chip.nチャンネル番号 ) )
+                            if ( ( chip.bWAVを使うチャンネルである && this.listWAV.TryGetValue( chip.n整数値_内部番号, out CWAV cwav ) ) && !cwav.listこのWAVを使用するチャンネル番号の集合.Contains( chip.nチャンネル番号 ) )
 							{
-								this.listWAV[ chip.n整数値_内部番号 ].listこのWAVを使用するチャンネル番号の集合.Add( chip.nチャンネル番号 );
+                                cwav.listこのWAVを使用するチャンネル番号の集合.Add( chip.nチャンネル番号 );
 
 								int c = chip.nチャンネル番号 >> 4;
 								switch ( c )
 								{
 									case 0x01:
-										this.listWAV[ chip.n整数値_内部番号 ].bIsDrumsSound = true; break;
+                                        cwav.bIsDrumsSound = true; break;
 									case 0x02:
-										this.listWAV[ chip.n整数値_内部番号 ].bIsGuitarSound = true; break;
+                                        cwav.bIsGuitarSound = true; break;
 									case 0x0A:
-										this.listWAV[ chip.n整数値_内部番号 ].bIsBassSound = true; break;
+                                        cwav.bIsBassSound = true; break;
 									case 0x06:
 									case 0x07:
 									case 0x08:
 									case 0x09:
-										this.listWAV[ chip.n整数値_内部番号 ].bIsSESound = true; break;
+                                        cwav.bIsSESound = true; break;
 									case 0x00:
 										if ( chip.nチャンネル番号 == 0x01 )
 										{
-											this.listWAV[ chip.n整数値_内部番号 ].bIsBGMSound = true; break;
+                                            cwav.bIsBGMSound = true; break;
 										}
 										break;
 								}
@@ -6434,9 +6432,8 @@ namespace DTXMania
 						#endregion
 
 						int duration = 0;
-						if ( listWAV.ContainsKey( pChip.n整数値_内部番号 ) )
+						if ( listWAV.TryGetValue( pChip.n整数値_内部番号, out CDTX.CWAV wc ) )
 						{
-							CDTX.CWAV wc = CDTXMania.DTX.listWAV[ pChip.n整数値_内部番号 ];
 							double _db再生速度 = ( CDTXMania.DTXVmode.Enabled ) ? this.dbDTXVPlaySpeed : this.db再生速度;
 							duration = ( wc.rSound[ 0 ] == null ) ? 0 : (int) ( wc.rSound[ 0 ].n総演奏時間ms / _db再生速度 );	// #23664 durationに再生速度が加味されておらず、低速再生でBGMが途切れる問題を修正 (発声時刻msは、DTX読み込み時に再生速度加味済)
 						}

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
@@ -308,9 +308,8 @@ namespace DTXMania
 					{
 						pChip.bHit = true;
 //						Trace.TraceInformation( "first [DA] BAR=" + pChip.n発声位置 / 384 + " ch=" + pChip.nチャンネル番号.ToString( "x2" ) + ", wav=" + pChip.n整数値 + ", time=" + pChip.n発声時刻ms );
-						if ( listWAV.ContainsKey( pChip.n整数値_内部番号 ) )
+						if ( listWAV.TryGetValue( pChip.n整数値_内部番号, out CDTX.CWAV wc ) )
 						{
-							CDTX.CWAV wc = listWAV[ pChip.n整数値_内部番号 ];
 							for ( int i = 0; i < nPolyphonicSounds; i++ )
 							{
 								if ( wc.rSound[ i ] != null )
@@ -3264,9 +3263,9 @@ namespace DTXMania
 							pChip.bHit = true;
                             if( pChip.nコース == this.n現在のコース[ nPlayer ] )
                             {
-							    if ( dTX.listBPM.ContainsKey( pChip.n整数値_内部番号 ) )
+							    if ( dTX.listBPM.TryGetValue( pChip.n整数値_内部番号, out CDTX.CBPM cBPM ) )
 							    {
-								    this.actPlayInfo.dbBPM = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );// + dTX.BASEBPM;
+                                    this.actPlayInfo.dbBPM = cBPM.dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 );// + dTX.BASEBPM;
 							    }
 
 
@@ -3445,9 +3444,8 @@ namespace DTXMania
 						{
 //Debug.WriteLine( "[DA(AddMixer)] BAR=" + pChip.n発声位置 / 384 + " ch=" + pChip.nチャンネル番号.ToString( "x2" ) + ", wav=" + pChip.n整数値.ToString( "x2" ) + ", time=" + pChip.n発声時刻ms );
 							pChip.bHit = true;
-							if ( listWAV.ContainsKey( pChip.n整数値_内部番号 ) )	// 参照が遠いので後日最適化する
+							if ( listWAV.TryGetValue( pChip.n整数値_内部番号, out CDTX.CWAV wc ) )	// 参照が遠いので後日最適化する
 							{
-								CDTX.CWAV wc = listWAV[ pChip.n整数値_内部番号 ];
 								for ( int i = 0; i < nPolyphonicSounds; i++ )
 								{
 									if ( wc.rSound[ i ] != null )
@@ -3466,9 +3464,8 @@ namespace DTXMania
 						{
 //Debug.WriteLine( "[DB(RemoveMixer)] BAR=" + pChip.n発声位置 / 384 + " ch=" + pChip.nチャンネル番号.ToString( "x2" ) + ", wav=" + pChip.n整数値.ToString( "x2" ) + ", time=" + pChip.n発声時刻ms );
 							pChip.bHit = true;
-							if ( listWAV.ContainsKey( pChip.n整数値_内部番号 ) )	// 参照が遠いので後日最適化する
+							if ( listWAV.TryGetValue( pChip.n整数値_内部番号, out CDTX.CWAV wc ) )	// 参照が遠いので後日最適化する
 							{
-							    CDTX.CWAV wc = listWAV[ pChip.n整数値_内部番号 ];
 							    for ( int i = 0; i < nPolyphonicSounds; i++ )
 							    {
 									if ( wc.rSound[ i ] != null )

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
@@ -679,8 +679,6 @@ namespace DTXMania
         protected int[] n現在の連打数 = new int[ 4 ];
         protected E連打State eRollState;
 
-        private int n連打終了時間ms;
-
         public CCounter ct制御タイマ;
 
         protected int nタイマ番号;
@@ -2778,39 +2776,41 @@ namespace DTXMania
 			{
 				return true;
 			}
-			if ( this.n現在のトップChip == -1 )
-			{
-				return true;
-			}
-            if( this.r指定時刻に一番近い未ヒットChip( (long)CSound管理.rc演奏用タイマ.n現在時刻ms, 0x50, 0, 1000000, nPlayer ) == null )
+
+			var n現在時刻ms = CSound管理.rc演奏用タイマ.n現在時刻ms;
+
+			if( this.r指定時刻に一番近い未ヒットChip( (long)n現在時刻ms, 0x50, 0, 1000000, nPlayer ) == null )
             {
                 this.actChara.b演奏中 = false;
             }
 
+			var db現在の譜面スクロール速度 = this.act譜面スクロール速度.db現在の譜面スクロール速度;
+
 			//double speed = 264.0;	// BPM150の時の1小節の長さ[dot]
 			const double speed = 324.0;	// BPM150の時の1小節の長さ[dot]
 
-			//double ScrollSpeedDrums = (( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
-            double ScrollSpeedDrums = ((  this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
-			double ScrollSpeedGuitar = ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Guitar + 1.0 ) * 0.5 * 0.5 * 37.5 * speed / 60000.0;
-			double ScrollSpeedBass = ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Bass + 1.0 ) * 0.5 * 0.5 * 37.5 * speed / 60000.0;
-            double ScrollSpeedTaiko = (( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
+			double ScrollSpeedDrums = (( db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
+			double ScrollSpeedGuitar = ( db現在の譜面スクロール速度.Guitar + 1.0 ) * 0.5 * 0.5 * 37.5 * speed / 60000.0;
+			double ScrollSpeedBass = ( db現在の譜面スクロール速度.Bass + 1.0 ) * 0.5 * 0.5 * 37.5 * speed / 60000.0;
+            double ScrollSpeedTaiko = (( db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
+
+			CConfigIni configIni = CDTXMania.ConfigIni;
 
 			CDTX dTX = CDTXMania.DTX;
             bool bAutoPlay = false;
             switch( nPlayer ) //2017.08.11 kairera0467
             {
                 case 0:
-                    bAutoPlay = CDTXMania.ConfigIni.b太鼓パートAutoPlay;
+                    bAutoPlay = configIni.b太鼓パートAutoPlay;
                     break;
                 case 1:
-                    bAutoPlay = CDTXMania.ConfigIni.b太鼓パートAutoPlay2P;
+                    bAutoPlay = configIni.b太鼓パートAutoPlay2P;
                     dTX = CDTXMania.DTX_2P;
                     break;
                 default:
                     break;
             }
-			CConfigIni configIni = CDTXMania.ConfigIni;
+
             if( this.n分岐した回数[ nPlayer ] == 0 )
             {
                 this.bUseBranch[ nPlayer ] = dTX.bHIDDENBRANCH ? false : dTX.bチップがある.Branch;
@@ -2826,15 +2826,16 @@ namespace DTXMania
 			{
 				CDTX.CChip pChip = dTX.listChip[ nCurrentTopChip ];
 //Debug.WriteLine( "nCurrentTopChip=" + nCurrentTopChip + ", ch=" + pChip.nチャンネル番号.ToString("x2") + ", 発音位置=" + pChip.n発声位置 + ", 発声時刻ms=" + pChip.n発声時刻ms );
-				pChip.nバーからの距離dot.Drums = (int) ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * ScrollSpeedDrums );
-				pChip.nバーからの距離dot.Guitar = (int) ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * ScrollSpeedGuitar );
-				pChip.nバーからの距離dot.Bass = (int) ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * ScrollSpeedBass );
-                pChip.nバーからの距離dot.Taiko = (int) ( ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
+				var time = pChip.n発声時刻ms - n現在時刻ms;
+				pChip.nバーからの距離dot.Drums = (int) ( time * ScrollSpeedDrums );
+				pChip.nバーからの距離dot.Guitar = (int) ( time * ScrollSpeedGuitar );
+				pChip.nバーからの距離dot.Bass = (int) ( time * ScrollSpeedBass );
+                pChip.nバーからの距離dot.Taiko = (int) ( ( time * pChip.dbBPM * pChip.dbSCROLL * (db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
                 pChip.nバーからのノーツ末端距離dot.Drums = 0;
                 pChip.nバーからのノーツ末端距離dot.Guitar = 0;
                 pChip.nバーからのノーツ末端距離dot.Bass = 0;
                 if( pChip.nノーツ終了時刻ms != 0 )
-                    pChip.nバーからのノーツ末端距離dot.Taiko = (int) ( ( ( pChip.nノーツ終了時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
+                    pChip.nバーからのノーツ末端距離dot.Taiko = (int) ( ( ( pChip.nノーツ終了時刻ms - n現在時刻ms) * pChip.dbBPM * pChip.dbSCROLL * (db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
 
                 if( configIni.eScrollMode == EScrollMode.BMSCROLL || configIni.eScrollMode == EScrollMode.HSSCROLL )
                 {
@@ -2845,26 +2846,28 @@ namespace DTXMania
 
                     var dbSCROLL = configIni.eScrollMode == EScrollMode.BMSCROLL ? 1.0 : pChip.dbSCROLL;
 
-                    pChip.nバーからの距離dot.Taiko = (int)( ( ( pChip.fBMSCROLLTime * NOTE_GAP ) - ( play_bpm_time * NOTE_GAP ) ) * dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) );
+                    pChip.nバーからの距離dot.Taiko = (int)( ( ( pChip.fBMSCROLLTime * NOTE_GAP ) - ( play_bpm_time * NOTE_GAP ) ) * dbSCROLL * ( db現在の譜面スクロール速度.Drums + 1.5 ) );
                     if( pChip.nノーツ終了時刻ms != 0 )
-                        pChip.nバーからのノーツ末端距離dot.Taiko = (int)( ( ( pChip.fBMSCROLLTime_end * NOTE_GAP) - ( play_bpm_time * NOTE_GAP ) ) * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) );
+                        pChip.nバーからのノーツ末端距離dot.Taiko = (int)( ( ( pChip.fBMSCROLLTime_end * NOTE_GAP) - ( play_bpm_time * NOTE_GAP ) ) * pChip.dbSCROLL * ( db現在の譜面スクロール速度.Drums + 1.5 ) );
                 }
-
-				bool bPChipIsAutoPlay = bCheckAutoPlay( pChip );
-
-				int nInputAdjustTime = ( bPChipIsAutoPlay || (pChip.e楽器パート == E楽器パート.UNKNOWN) )? 0 : this.nInputAdjustTimeMs[ (int) pChip.e楽器パート ];
 
 				int instIndex = (int) pChip.e楽器パート;
 
-                if( pChip.nチャンネル番号 >= 0x11 && pChip.nチャンネル番号 <= 0x14 || pChip.nチャンネル番号 == 0x1A || pChip.nチャンネル番号 == 0x1B )//|| pChip.nチャンネル番号 == 0x9A )
+                if (!pChip.bHit)
                 {
-				    if ( ( !pChip.bHit ) && ( ( pChip.n発声時刻ms + 120 ) < CSound管理.rc演奏用タイマ.n現在時刻ms )
-                        && ( this.e指定時刻からChipのJUDGEを返す( CSound管理.rc演奏用タイマ.n現在時刻, pChip, nInputAdjustTime ) == E判定.Miss ) )
-                       //( ( pChip.nバーからの距離dot.Taiko < -40 ) && ( this.e指定時刻からChipのJUDGEを返す( CSound管理.rc演奏用タイマ.n現在時刻, pChip, nInputAdjustTime ) == E判定.Miss ) ) )
-				    {
-    				    this.tチップのヒット処理( CSound管理.rc演奏用タイマ.n現在時刻, pChip, E楽器パート.TAIKO, false, 0, nPlayer );
-                        pChip.eNoteState = ENoteState.bad;
-	    			}
+                    if( pChip.nチャンネル番号 >= 0x11 && pChip.nチャンネル番号 <= 0x14 || pChip.nチャンネル番号 == 0x1A || pChip.nチャンネル番号 == 0x1B )//|| pChip.nチャンネル番号 == 0x9A )
+                    {
+                        if ( ( pChip.n発声時刻ms + 120 ) < n現在時刻ms )
+                        {
+                            int nInputAdjustTime = ( (pChip.e楽器パート == E楽器パート.UNKNOWN) || bCheckAutoPlay( pChip ) )? 0 : this.nInputAdjustTimeMs [ (int) pChip.e楽器パート ];
+                            if ( this.e指定時刻からChipのJUDGEを返す( n現在時刻ms, pChip, nInputAdjustTime ) == E判定.Miss )
+                            //( ( pChip.nバーからの距離dot.Taiko < -40 ) && ( this.e指定時刻からChipのJUDGEを返す( CSound管理.rc演奏用タイマ.n現在時刻, pChip, nInputAdjustTime ) == E判定.Miss ) ) )
+                            {
+                                this.tチップのヒット処理( n現在時刻ms, pChip, E楽器パート.TAIKO, false, 0, nPlayer );
+                                pChip.eNoteState = ENoteState.bad;
+                            }
+                        }
+                    }
                 }
 
                 if( pChip.nバーからの距離dot[ instIndex ] < -150 )
@@ -2878,17 +2881,17 @@ namespace DTXMania
                     }
                 }
 
-                if( chip現在処理中の連打チップ[ nPlayer ] != null )
+                var cChipCurrentlyInProcess = chip現在処理中の連打チップ[ nPlayer ];
+                if( cChipCurrentlyInProcess != null && !cChipCurrentlyInProcess.bHit )
                 {
-                    if( chip現在処理中の連打チップ[ nPlayer ].nチャンネル番号 >= 0x13 && chip現在処理中の連打チップ[ nPlayer ].nチャンネル番号 <= 0x15 )//|| pChip.nチャンネル番号 == 0x9A )
+                    if( cChipCurrentlyInProcess.nチャンネル番号 >= 0x13 && cChipCurrentlyInProcess.nチャンネル番号 <= 0x15 )//|| pChip.nチャンネル番号 == 0x9A )
                     {
-				        if ( ( !chip現在処理中の連打チップ[ nPlayer ].bHit ) &&
-                           ( ( chip現在処理中の連打チップ[ nPlayer ].nバーからの距離dot.Taiko < -500 ) && ( chip現在処理中の連打チップ[ nPlayer ].n発声時刻ms <= CSound管理.rc演奏用タイマ.n現在時刻ms && chip現在処理中の連打チップ[ nPlayer ].nノーツ終了時刻ms >= CSound管理.rc演奏用タイマ.n現在時刻ms ) ) )
+				        if ( ( ( cChipCurrentlyInProcess.nバーからの距離dot.Taiko < -500 ) && ( cChipCurrentlyInProcess.n発声時刻ms <= n現在時刻ms && cChipCurrentlyInProcess.nノーツ終了時刻ms >= n現在時刻ms ) ) )
                            //( ( chip現在処理中の連打チップ.nバーからのノーツ末端距離dot.Taiko < -500 ) && ( chip現在処理中の連打チップ.n発声時刻ms <= CSound管理.rc演奏用タイマ.n現在時刻ms && chip現在処理中の連打チップ.nノーツ終了時刻ms >= CSound管理.rc演奏用タイマ.n現在時刻ms ) ) )
                            //( ( pChip.n発声時刻ms <= CSound管理.rc演奏用タイマ.n現在時刻ms && pChip.nノーツ終了時刻ms >= CSound管理.rc演奏用タイマ.n現在時刻ms ) ) )
 		    		    {
                             if( bAutoPlay )
-    		    		        this.tチップのヒット処理( CSound管理.rc演奏用タイマ.n現在時刻, chip現在処理中の連打チップ[ nPlayer ], E楽器パート.TAIKO, false, 0, nPlayer );
+    		    		        this.tチップのヒット処理( n現在時刻ms, cChipCurrentlyInProcess, E楽器パート.TAIKO, false, 0, nPlayer );
 	    		    	}
                     }
                 }
@@ -2927,19 +2930,19 @@ namespace DTXMania
 						if ( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) )
 						{
 							pChip.bHit = true;
-                            if( pChip.nコース == this.n現在のコース[ nPlayer ] )
-                            {
-							    if ( dTX.listBPM.ContainsKey( pChip.n整数値_内部番号 ) )
-							    {
+                            //if( pChip.nコース == this.n現在のコース[ nPlayer ] )
+                            //{
+							    //if ( dTX.listBPM.ContainsKey( pChip.n整数値_内部番号 ) )
+							    //{
 								    //this.actPlayInfo.dbBPM = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );// + dTX.BASEBPM;
-							    }
+							    //}
                                 //double bpm = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );
                                 //int nUnit = (int)((60.0 / ( bpm ) / this.actChara.nキャラクター通常モーション枚数 ) * 1000 );
                                 //int nUnit_gogo = (int)((60.0 / ( bpm ) / this.actChara.nキャラクターゴーゴーモーション枚数 ) * 1000 );
                                 //this.actChara.ct通常モーション = new CCounter( 0, this.actChara.nキャラクター通常モーション枚数 - 1, nUnit, CDTXMania.Timer );
                                 //this.actChara.ctゴーゴーモーション = new CCounter(0, this.actChara.nキャラクターゴーゴーモーション枚数 - 1, nUnit_gogo * 2, CDTXMania.Timer);
 
-                            }
+                            //}
 						}
 						break;
 					#endregion
@@ -2957,30 +2960,30 @@ namespace DTXMania
 					case 0x15:
 					case 0x16:
 					case 0x17:
-					case 0x18:
                         {
                             //2015.03.28 kairera0467
                             //描画順序を変えるため、メイン処理だけをこちらに残して描画処理は分離。
 
                             //this.t進行描画_チップ_Taiko連打(configIni, ref dTX, ref pChip);
-                            int t = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
                             //2015.04.13 kairera0467 ここを外さないと恋文2000の連打に対応できず、ここをつけないと他のコースと重なっている連打をどうにもできない。
                             //常時実行メソッドに渡したら対応できた!?
                             //if ((!pChip.bHit && (pChip.nバーからの距離dot.Drums < 0)))
                             {
-                                if( ( pChip.n発声時刻ms <= (int)CSound管理.rc演奏用タイマ.n現在時刻ms && pChip.nノーツ終了時刻ms >= (int)CSound管理.rc演奏用タイマ.n現在時刻ms ) && pChip.nチャンネル番号 != 0x18 )
+                                if( ( pChip.n発声時刻ms <= (int)n現在時刻ms && pChip.nノーツ終了時刻ms >= (int)n現在時刻ms ) )
                                 {
                                     //if( this.n現在のコース == pChip.nコース )
                                     if( pChip.b可視 == true )
                                         this.chip現在処理中の連打チップ[ nPlayer ] = pChip;
                                 }
                             }
+                            if (pChip.n描画優先度 <= 0)
+                                this.t進行描画_チップ_Taiko連打(configIni, ref dTX, ref pChip, nPlayer);
+                        }
 
-                            if( ( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) ) && pChip.nチャンネル番号 != 0x18 )
-                            {
-                                this.n連打終了時間ms = pChip.nノーツ終了時刻ms;
-                            }
-                            else if( ( !pChip.bHit && (pChip.nバーからの距離dot.Drums < 0 ) ) && pChip.nチャンネル番号 == 0x18 )
+                        break;
+                    case 0x18:
+                        {
+                            if( ( !pChip.bHit && (pChip.nバーからの距離dot.Drums < 0 ) ) )
                             {
                                 this.b連打中[ nPlayer ] = false;
                                 this.actRoll.b表示[ nPlayer ] = false;
@@ -3055,24 +3058,14 @@ namespace DTXMania
                                 this.actChara.b演奏中 = true;
                                 if( this.actPlayInfo.n小節番号 == 0 )
                                 {
-                                    double dbUnit = ( ( ( 60.0 / ( CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM ) ) ));
-                                    double dbUnit_gogo = ( ( ( 60.0 / ( CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM ) ) ) );
-                                    double dbUnit_clear = ( ( ( 60.0f / ( CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM ) ) ) );
-
                                     for (int i = 0; i < 2; i++)
                                     {
                                         ctChipAnime[i] = new CCounter(0, 3, 60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM * 1 / 4, CSound管理.rc演奏用タイマ);
                                     }
 
-                                    dbUnit = Math.Ceiling( dbUnit * 1000.0 );
-                                    dbUnit = dbUnit / 1000.0;
-
-                                    double dbPtn_Normal = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Normal / this.actChara.arモーション番号.Length;
-                                    double dbPtn_Clear = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Clear / this.actChara.arクリアモーション番号.Length;
-                                    double dbPtn_GoGo = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_GoGo / this.actChara.arゴーゴーモーション番号.Length;
-
                                     if (CDTXMania.Skin.Game_Chara_Ptn_Normal != 0)
                                     {
+                                        double dbPtn_Normal = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Normal / this.actChara.arモーション番号.Length;
                                         this.actChara.ctChara_Normal = new CCounter(0, this.actChara.arモーション番号.Length - 1, dbPtn_Normal, CSound管理.rc演奏用タイマ);
                                     }
                                     else
@@ -3081,6 +3074,7 @@ namespace DTXMania
                                     }
                                     if (CDTXMania.Skin.Game_Chara_Ptn_Clear != 0)
                                     {
+                                        double dbPtn_Clear = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Clear / this.actChara.arクリアモーション番号.Length;
                                         this.actChara.ctChara_Clear = new CCounter(0, this.actChara.arクリアモーション番号.Length - 1, dbPtn_Clear, CSound管理.rc演奏用タイマ);
                                     }
                                     else
@@ -3089,6 +3083,7 @@ namespace DTXMania
                                     }
                                     if (CDTXMania.Skin.Game_Chara_Ptn_GoGo != 0)
                                     {
+                                        double dbPtn_GoGo = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_GoGo / this.actChara.arゴーゴーモーション番号.Length;
                                         this.actChara.ctChara_GoGo = new CCounter(0, this.actChara.arゴーゴーモーション番号.Length - 1, dbPtn_GoGo, CSound管理.rc演奏用タイマ);
                                     }
                                     else
@@ -3273,12 +3268,7 @@ namespace DTXMania
 							    {
 								    this.actPlayInfo.dbBPM = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );// + dTX.BASEBPM;
 							    }
-                                double bpm = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );
-                                double dbUnit = ( ( ( 60.0 / ( bpm ) ) ));
 
-                                double dbPtn_Normal = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Normal / this.actChara.arモーション番号.Length;
-                                double dbPtn_Clear = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Clear / this.actChara.arクリアモーション番号.Length;
-                                double dbPtn_GoGo = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_GoGo / this.actChara.arゴーゴーモーション番号.Length;
 
                                 for (int i = 0; i < 2; i++)
                                 {
@@ -3287,6 +3277,7 @@ namespace DTXMania
 
                                 if (CDTXMania.Skin.Game_Chara_Ptn_Normal != 0)
                                 {
+                                    double dbPtn_Normal = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Normal / this.actChara.arモーション番号.Length;
                                     this.actChara.ctChara_Normal = new CCounter(0, this.actChara.arモーション番号.Length - 1, dbPtn_Normal, CSound管理.rc演奏用タイマ);
                                 } else
                                 {
@@ -3294,6 +3285,7 @@ namespace DTXMania
                                 }
                                 if (CDTXMania.Skin.Game_Chara_Ptn_Clear != 0)
                                 {
+                                    double dbPtn_Clear = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_Clear / this.actChara.arクリアモーション番号.Length;
                                     this.actChara.ctChara_Clear = new CCounter(0, this.actChara.arクリアモーション番号.Length - 1, dbPtn_Clear, CSound管理.rc演奏用タイマ);
                                 }
                                 else
@@ -3302,6 +3294,7 @@ namespace DTXMania
                                 }
                                 if (CDTXMania.Skin.Game_Chara_Ptn_GoGo != 0)
                                 {
+                                    double dbPtn_GoGo = (60.0 / CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM) * CDTXMania.Skin.Game_Chara_Beat_GoGo / this.actChara.arゴーゴーモーション番号.Length;
                                     this.actChara.ctChara_GoGo = new CCounter(0, this.actChara.arゴーゴーモーション番号.Length - 1, dbPtn_GoGo, CSound管理.rc演奏用タイマ);
                                 } else
                                 {
@@ -3346,10 +3339,10 @@ namespace DTXMania
 						if ( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) )
 						{
 							pChip.bHit = true;
-							if ( dTX.listSCROLL.ContainsKey( pChip.n整数値_内部番号 ) )
-							{
+							//if ( dTX.listSCROLL.ContainsKey( pChip.n整数値_内部番号 ) )
+							//{
 								//this.actPlayInfo.dbBPM = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );// + dTX.BASEBPM;
-							}
+							//}
 						}
                         break;
 
@@ -3358,8 +3351,8 @@ namespace DTXMania
                         {
                             pChip.bHit = true;
                             this.bIsGOGOTIME[ nPlayer ] = true;
-                            double dbUnit = (((60.0 / (CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM))));
-                            dbUnit = (((60.0 / pChip.dbBPM)));
+                            //double dbUnit = (((60.0 / (CDTXMania.stage演奏ドラム画面.actPlayInfo.dbBPM))));
+                            double dbUnit = (((60.0 / pChip.dbBPM)));
                             if(nPlayer == 0)
                             {
                                 if (CDTXMania.Skin.Game_Chara_Ptn_GoGoStart != 0 && nPlayer == 0)
@@ -3497,10 +3490,10 @@ namespace DTXMania
 						if ( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) )
 						{
 							pChip.bHit = true;
-							if ( dTX.listDELAY.ContainsKey( pChip.n整数値_内部番号 ) )
-							{
+							//if ( dTX.listDELAY.ContainsKey( pChip.n整数値_内部番号 ) )
+							//{
 								//this.actPlayInfo.dbBPM = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );// + dTX.BASEBPM;
-							}
+							//}
 						}
                         break;
                     case 0xDD: //譜面分岐条件リセット
@@ -3530,7 +3523,7 @@ namespace DTXMania
                             //if( n現在のコース == pChip.nコース )
                                 this.n分岐した回数[ nPlayer ]++;
 
-                            if( CDTXMania.ConfigIni.bAutoSection )
+                            if( configIni.bAutoSection )
                             {
                                 this.tBranchReset( nPlayer );
                             }
@@ -3553,11 +3546,11 @@ namespace DTXMania
                         }
                         break;
                     case 0xE0:
-                        if( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) )
-                        {
+                        //if( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) )
+                        //{
                             //#BARLINEONと#BARLINEOFF
                             //演奏中は使用しません。
-                        }
+                        //}
                         break;
                     case 0xE1:
                         if( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) )
@@ -3615,11 +3608,6 @@ namespace DTXMania
 			return false;
 		}
 
-        protected bool t進行描画_チップ_連打( E楽器パート ePlayMode )
-        {
-            return this.t進行描画_チップ_連打( ePlayMode, 0 );
-        }
-
         protected bool t進行描画_チップ_連打( E楽器パート ePlayMode, int nPlayer )
 		{
 			if ( ( base.eフェーズID == CStage.Eフェーズ.演奏_STAGE_FAILED ) || ( base.eフェーズID == CStage.Eフェーズ.演奏_STAGE_FAILED_フェードアウト ) )
@@ -3630,80 +3618,47 @@ namespace DTXMania
 			{
 				return true;
 			}
-			if ( this.n現在のトップChip == -1 )
-			{
-				return true;
-			}
 
-			//double speed = 264.0;	// BPM150の時の1小節の長さ[dot]
-			const double speed = 324.0;	// BPM150の時の1小節の長さ[dot]
-
-			//double ScrollSpeedDrums = (( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
-            double ScrollSpeedDrums = ((  this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
-			double ScrollSpeedGuitar = ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Guitar + 1.0 ) * 0.5 * 0.5 * 37.5 * speed / 60000.0;
-			double ScrollSpeedBass = ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Bass + 1.0 ) * 0.5 * 0.5 * 37.5 * speed / 60000.0;
-            double ScrollSpeedTaiko = (( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.0 ) * speed ) * 0.5 * 37.5 / 60000.0;
+			CConfigIni configIni = CDTXMania.ConfigIni;
 
 			CDTX dTX = CDTXMania.DTX;
             bool bAutoPlay = false;
             switch( nPlayer ) //2017.08.11 kairera0467
             {
                 case 0:
-                    bAutoPlay = CDTXMania.ConfigIni.b太鼓パートAutoPlay;
+                    bAutoPlay = configIni.b太鼓パートAutoPlay;
                     break;
                 case 1:
-                    bAutoPlay = CDTXMania.ConfigIni.b太鼓パートAutoPlay2P;
+                    bAutoPlay = configIni.b太鼓パートAutoPlay2P;
                     dTX = CDTXMania.DTX_2P;
                     break;
                 default:
                     break;
             }
-			CConfigIni configIni = CDTXMania.ConfigIni;
 
-            float? play_bpm_time = null;
+			var n現在時刻ms = CSound管理.rc演奏用タイマ.n現在時刻ms;
 
             //for ( int nCurrentTopChip = this.n現在のトップChip; nCurrentTopChip < dTX.listChip.Count; nCurrentTopChip++ )
             for ( int nCurrentTopChip = dTX.listChip.Count - 1; nCurrentTopChip > 0; nCurrentTopChip-- )
 			{
 				CDTX.CChip pChip = dTX.listChip[ nCurrentTopChip ];
 
-//Debug.WriteLine( "nCurrentTopChip=" + nCurrentTopChip + ", ch=" + pChip.nチャンネル番号.ToString("x2") + ", 発音位置=" + pChip.n発声位置 + ", 発声時刻ms=" + pChip.n発声時刻ms );
-				pChip.nバーからの距離dot.Drums = (int) ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * ScrollSpeedDrums );
-				pChip.nバーからの距離dot.Guitar = (int) ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * ScrollSpeedGuitar );
-				pChip.nバーからの距離dot.Bass = (int) ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * ScrollSpeedBass );
-                pChip.nバーからの距離dot.Taiko = (int) ( ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
-                pChip.nバーからのノーツ末端距離dot.Drums = 0;
-                pChip.nバーからのノーツ末端距離dot.Guitar = 0;
-                pChip.nバーからのノーツ末端距離dot.Bass = 0;
-                if( pChip.nノーツ終了時刻ms != 0 )
-                    pChip.nバーからのノーツ末端距離dot.Taiko = (int) ( ( ( pChip.nノーツ終了時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
-
-                if( configIni.eScrollMode == EScrollMode.BMSCROLL || configIni.eScrollMode == EScrollMode.HSSCROLL )
+                if ( !pChip.bHit )
                 {
-                    if ( !play_bpm_time.HasValue )
+                    bool bRollChip = pChip.nチャンネル番号 >= 0x15 && pChip.nチャンネル番号 <= 0x19;
+                    if( bRollChip && ( ( pChip.e楽器パート != E楽器パート.UNKNOWN ) ) )
                     {
-                        play_bpm_time = this.GetNowPBMTime( dTX, 0 );
+                        int instIndex = (int) pChip.e楽器パート;
+                        if( pChip.nバーからの距離dot[instIndex] < -40 )
+                        {
+                            int nInputAdjustTime = ( (pChip.e楽器パート == E楽器パート.UNKNOWN) || bCheckAutoPlay( pChip ) )? 0 : this.nInputAdjustTimeMs[ (int) pChip.e楽器パート ];
+                            if ( this.e指定時刻からChipのJUDGEを返す( n現在時刻ms, pChip, nInputAdjustTime ) == E判定.Miss )
+                            {
+                                this.tチップのヒット処理( n現在時刻ms, pChip, E楽器パート.TAIKO, false, 0, nPlayer );
+                            }
+                        }
                     }
-
-                    var dbSCROLL = configIni.eScrollMode == EScrollMode.BMSCROLL ? 1.0 : pChip.dbSCROLL;
-
-                    pChip.nバーからの距離dot.Taiko = (int)( ( ( pChip.fBMSCROLLTime * NOTE_GAP ) - ( play_bpm_time * NOTE_GAP ) ) * dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) );
-                    if( pChip.nノーツ終了時刻ms != 0 )
-                        pChip.nバーからのノーツ末端距離dot.Taiko = (int)( ( ( pChip.fBMSCROLLTime_end * NOTE_GAP ) - ( play_bpm_time * NOTE_GAP ) ) * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) );
                 }
-
-				bool bPChipIsAutoPlay = bCheckAutoPlay( pChip );
-
-				int nInputAdjustTime = ( bPChipIsAutoPlay || (pChip.e楽器パート == E楽器パート.UNKNOWN) )? 0 : this.nInputAdjustTimeMs[ (int) pChip.e楽器パート ];
-
-				int instIndex = (int) pChip.e楽器パート;
-                bool bRollChip = pChip.nチャンネル番号 >= 0x15 && pChip.nチャンネル番号 <= 0x19;
-
-                if ( bRollChip && ( ( pChip.e楽器パート != E楽器パート.UNKNOWN ) && !pChip.bHit ) &&
-				       ( ( pChip.nバーからの距離dot[ instIndex ] < -40 ) && ( this.e指定時刻からChipのJUDGEを返す( CSound管理.rc演奏用タイマ.n現在時刻, pChip, nInputAdjustTime ) == E判定.Miss ) ) )
-				{
-    			    this.tチップのヒット処理( CSound管理.rc演奏用タイマ.n現在時刻, pChip, E楽器パート.TAIKO, false, 0, nPlayer );
-	    	    }
 
 				switch ( pChip.nチャンネル番号 )
 				{

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
@@ -1263,8 +1263,6 @@ namespace DTXMania
 		protected override void t進行描画_チップ_Taiko( CConfigIni configIni, ref CDTX dTX, ref CDTX.CChip pChip, int nPlayer )
         {
             int nLane = 0;
-            int nノート座標 = 0;
-            int nSenotesY = CDTXMania.Skin.nSENotesY[ nPlayer ];
 
             #region[ 作り直したもの ]
             if( pChip.b可視 )
@@ -1307,7 +1305,7 @@ namespace DTXMania
                     }
 
 
-                    if ( ( CSound管理.rc演奏用タイマ.n現在時刻ms < pChip.n発声時刻ms - pChip.nノーツ出現時刻ms ) && pChip.nノーツ出現時刻ms != 0 )
+                    if ( pChip.nノーツ出現時刻ms != 0 && ( nPlayTime < pChip.n発声時刻ms - pChip.nノーツ出現時刻ms ) )
                         pChip.bShow = false;
                     else
                         pChip.bShow = true;
@@ -1326,23 +1324,20 @@ namespace DTXMania
                             break;
                     }
 
-                    if( ( CSound管理.rc演奏用タイマ.n現在時刻ms < pChip.n発声時刻ms - pChip.nノーツ移動開始時刻ms ) && pChip.nノーツ移動開始時刻ms != 0 )
+                    int x = 0;
+                    int y = CDTXMania.Skin.nScrollFieldY[nPlayer];
+
+                    if ( pChip.nノーツ移動開始時刻ms != 0 && ( nPlayTime < pChip.n発声時刻ms - pChip.nノーツ移動開始時刻ms ) )
                     {
-                        nノート座標 = (int)( ( ( ( pChip.n発声時刻ms ) - ( pChip.n発声時刻ms - pChip.nノーツ移動開始時刻ms ) ) * pChip.dbBPM * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
+                        x = (int)( ( ( ( pChip.n発声時刻ms ) - ( pChip.n発声時刻ms - pChip.nノーツ移動開始時刻ms ) ) * pChip.dbBPM * pChip.dbSCROLL * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
                     }
                     else
-                        nノート座標 = 0;
-
-                    int x = ( CDTXMania.Skin.nScrollFieldX[ nPlayer ] ) + pChip.nバーからの距離dot.Taiko;
-                    int y = CDTXMania.Skin.nScrollFieldY[ nPlayer ];
+                    {
+                        x = pChip.nバーからの距離dot.Taiko;
+                    }
 
                     int xTemp = 0;
                     int yTemp = 0;
-
-                    if( ( CSound管理.rc演奏用タイマ.n現在時刻ms < pChip.n発声時刻ms - pChip.nノーツ移動開始時刻ms ) && pChip.nノーツ移動開始時刻ms != 0 )
-                        x = nノート座標;
-                    else
-                        x = pChip.nバーからの距離dot.Taiko;
 
                     #region[ スクロール方向変更 ]
                     if( pChip.nスクロール方向 != 0 )
@@ -1386,7 +1381,6 @@ namespace DTXMania
                     #endregion
 
                     #region[ 両手待ち時 ]
-                    float time = pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻ms;
                     if( pChip.eNoteState == ENoteState.wait )
                     {
                         x = ( CDTXMania.Skin.nScrollFieldX[0] );
@@ -1408,9 +1402,6 @@ namespace DTXMania
                         else if( CDTXMania.ConfigIni.eScrollMode == EScrollMode.BMSCROLL || CDTXMania.ConfigIni.eScrollMode == EScrollMode.HSSCROLL )
                             y += pChip.nバーからの距離dot.Taiko;
                     }
-
-                    Matrix mat = Matrix.Identity;
-                    mat *= Matrix.Translation( (float)(x - 640.0f), -(y - 360.0f + 65.0f), 0f );
 
                     if( pChip.nバーからの距離dot.Drums < 0 )
                     {
@@ -1486,6 +1477,7 @@ namespace DTXMania
 
 
 
+                            int nSenotesY = CDTXMania.Skin.nSENotesY[nPlayer];
                             this.ct手つなぎ.t進行Loop();
                             int nHand = this.ct手つなぎ.n現在の値 < 30 ? this.ct手つなぎ.n現在の値 : 60 - this.ct手つなぎ.n現在の値;
 
@@ -1493,6 +1485,7 @@ namespace DTXMania
                             x = ( x ) - ( ( int ) ( ( 130.0 * pChip.dbチップサイズ倍率 ) / 2.0 ) );
                             CDTXMania.Tx.Notes.b加算合成 = false;
                             CDTXMania.Tx.SenNotes.b加算合成 = false;
+                            var device = CDTXMania.app.Device;
                             switch ( pChip.nチャンネル番号 )
                             {
                                 case 0x11:
@@ -1500,8 +1493,8 @@ namespace DTXMania
                                     if( CDTXMania.Tx.Notes != null )
                                     {
                                         if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
-                                            CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 130, num9, 130, 130 ) );
-                                        CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
+                                            CDTXMania.Tx.Notes.t2D描画( device, x, y, new Rectangle( 130, num9, 130, 130 ) );
+                                        CDTXMania.Tx.SenNotes.t2D描画( device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
                                         //CDTXMania.act文字コンソール.tPrint( x + 60, y + 140, C文字コンソール.Eフォント種別.白, pChip.nSenote.ToString() );
                                     }
                                     break;
@@ -1510,8 +1503,8 @@ namespace DTXMania
                                     if( CDTXMania.Tx.Notes != null )
                                     {
                                         if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
-                                            CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 260, num9, 130, 130) );
-                                        CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
+                                            CDTXMania.Tx.Notes.t2D描画( device, x, y, new Rectangle( 260, num9, 130, 130) );
+                                        CDTXMania.Tx.SenNotes.t2D描画( device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
                                         //CDTXMania.act文字コンソール.tPrint( x + 60, y + 140, C文字コンソール.Eフォント種別.白, pChip.nSenote.ToString() );
                                     }
                                     nLane = 1;
@@ -1522,10 +1515,10 @@ namespace DTXMania
                                     {
                                         if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
                                         {
-                                            CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 390, num9, 130, 130 ) );
-                                            //CDTXMania.Tx.Notes.t3D描画( CDTXMania.app.Device, mat, new Rectangle( 390, num9, 130, 130 ) );
+                                            CDTXMania.Tx.Notes.t2D描画( device, x, y, new Rectangle( 390, num9, 130, 130 ) );
+                                            //CDTXMania.Tx.Notes.t3D描画( device, mat, new Rectangle( 390, num9, 130, 130 ) );
                                         }
-                                        CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
+                                        CDTXMania.Tx.SenNotes.t2D描画( device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
                                         //CDTXMania.act文字コンソール.tPrint( x + 60, y + 140, C文字コンソール.Eフォント種別.白, pChip.nSenote.ToString() );
                                     }
                                     break;
@@ -1534,8 +1527,8 @@ namespace DTXMania
                                     if( CDTXMania.Tx.Notes != null )
                                     {
                                         if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
-                                            CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 520, num9, 130, 130 ) );
-                                        CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
+                                            CDTXMania.Tx.Notes.t2D描画( device, x, y, new Rectangle( 520, num9, 130, 130 ) );
+                                        CDTXMania.Tx.SenNotes.t2D描画( device, x - 2, y + nSenotesY, new Rectangle( 0, 30 * pChip.nSenote, 136, 30 ) );
                                         //CDTXMania.act文字コンソール.tPrint( x + 60, y + 140, C文字コンソール.Eフォント種別.白, pChip.nSenote.ToString() );
                                     }
                                     nLane = 1;
@@ -1548,18 +1541,18 @@ namespace DTXMania
                                         {
                                             if( nPlayer == 0 )
                                             {
-                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( CDTXMania.app.Device, x + 25, ( y + 74 ) + nHand );
-                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( CDTXMania.app.Device, x + 60, ( y + 104 ) - nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( device, x + 25, ( y + 74 ) + nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( device, x + 60, ( y + 104 ) - nHand );
                                             }
                                             else if( nPlayer == 1 )
                                             {
-                                                CDTXMania.Tx.Notes_Arm.t2D描画( CDTXMania.app.Device, x + 25, ( y - 44 ) + nHand );
-                                                CDTXMania.Tx.Notes_Arm.t2D描画( CDTXMania.app.Device, x + 60, ( y - 14 ) - nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D描画( device, x + 25, ( y - 44 ) + nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D描画( device, x + 60, ( y - 14 ) - nHand );
                                             }
-                                            CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 1690, num9, 130, 130 ) );
-                                            //CDTXMania.Tx.Notes.t3D描画( CDTXMania.app.Device, mat, new Rectangle( 390, num9, 130, 130 ) );
+                                            CDTXMania.Tx.Notes.t2D描画( device, x, y, new Rectangle( 1690, num9, 130, 130 ) );
+                                            //CDTXMania.Tx.Notes.t3D描画( device, mat, new Rectangle( 390, num9, 130, 130 ) );
                                         }
-                                        CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x - 2, y + nSenotesY, new Rectangle( 0, 390, 136, 30 ) );
+                                        CDTXMania.Tx.SenNotes.t2D描画( device, x - 2, y + nSenotesY, new Rectangle( 0, 390, 136, 30 ) );
                                     }
                                     break;
 
@@ -1570,17 +1563,17 @@ namespace DTXMania
                                         {
                                             if( nPlayer == 0 )
                                             {
-                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( CDTXMania.app.Device, x + 25, ( y + 74 ) + nHand );
-                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( CDTXMania.app.Device, x + 60, ( y + 104 ) - nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( device, x + 25, ( y + 74 ) + nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D上下反転描画( device, x + 60, ( y + 104 ) - nHand );
                                             }
                                             else if( nPlayer == 1 )
                                             {
-                                                CDTXMania.Tx.Notes_Arm.t2D描画( CDTXMania.app.Device, x + 25, ( y - 44 ) + nHand );
-                                                CDTXMania.Tx.Notes_Arm.t2D描画( CDTXMania.app.Device, x + 60, ( y - 14 ) - nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D描画( device, x + 25, ( y - 44 ) + nHand );
+                                                CDTXMania.Tx.Notes_Arm.t2D描画( device, x + 60, ( y - 14 ) - nHand );
                                             }
-                                            CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 1820, num9, 130, 130 ) );
+                                            CDTXMania.Tx.Notes.t2D描画( device, x, y, new Rectangle( 1820, num9, 130, 130 ) );
                                         }
-                                        CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x - 2, y + nSenotesY, new Rectangle( 0, 420, 136, 30 ) );
+                                        CDTXMania.Tx.SenNotes.t2D描画( device, x - 2, y + nSenotesY, new Rectangle( 0, 420, 136, 30 ) );
                                     }
                                     nLane = 1;
                                     break;
@@ -1916,10 +1909,6 @@ namespace DTXMania
                 y += (int) ( ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL_Y * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
             }
 
-            Matrix mat = Matrix.Identity;
-            mat *= Matrix.RotationZ( C変換.DegreeToRadian( -(90.0f * (float)pChip.dbSCROLL_Y) ) );
-            mat *= Matrix.Translation( (float)(x - 640.0f) - 1.5f, -(y - 360.0f + 65.0f), 0f );
-
 			if ( !pChip.bHit && pChip.n発声時刻ms > CSound管理.rc演奏用タイマ.n現在時刻 )
 			{
 				//pChip.bHit = true;
@@ -1942,6 +1931,10 @@ namespace DTXMania
 			{
                 if( x >= 0 )
                 {
+                    Matrix mat = Matrix.Identity;
+                    mat *= Matrix.RotationZ(C変換.DegreeToRadian(-(90.0f * (float)pChip.dbSCROLL_Y)));
+                    mat *= Matrix.Translation((float)(x - 640.0f) - 1.5f, -(y - 360.0f + 65.0f), 0f);
+
                     if( pChip.bBranch )
                     {
                         //this.tx小節線_branch.t2D描画( CDTXMania.app.Device, x - 3, y, new Rectangle( 0, 0, 3, 130 ) );

--- a/FDK17プロジェクト/コード/04.グラフィック/CTexture.cs
+++ b/FDK17プロジェクト/コード/04.グラフィック/CTexture.cs
@@ -962,7 +962,6 @@ namespace FDK
         {
             if (this.b加算合成)
             {
-                device.SetRenderState(RenderState.AlphaBlendEnable, true);
                 device.SetRenderState(RenderState.SourceBlend, SlimDX.Direct3D9.Blend.SourceAlpha);             // 5
                 device.SetRenderState(RenderState.DestinationBlend, SlimDX.Direct3D9.Blend.One);                    // 2
             }
@@ -976,7 +975,6 @@ namespace FDK
             else if (this.b減算合成)
             {
                 //参考:http://www3.pf-x.net/~chopper/home2/DirectX/MD20.html
-                device.SetRenderState(RenderState.AlphaBlendEnable, true);
                 device.SetRenderState(RenderState.BlendOperation, SlimDX.Direct3D9.BlendOperation.Subtract);
                 device.SetRenderState(RenderState.SourceBlend, SlimDX.Direct3D9.Blend.One);
                 device.SetRenderState(RenderState.DestinationBlend, SlimDX.Direct3D9.Blend.One);
@@ -985,13 +983,11 @@ namespace FDK
             {
                 //参考:http://sylphylunar.seesaa.net/article/390331341.html
                 //C++から引っ張ってきたのでちょっと不安。
-                device.SetRenderState(RenderState.AlphaBlendEnable, true);
                 device.SetRenderState(RenderState.SourceBlend, SlimDX.Direct3D9.Blend.InverseDestinationColor);
                 device.SetRenderState(RenderState.DestinationBlend, SlimDX.Direct3D9.Blend.One);
             }
             else
             {
-                device.SetRenderState(RenderState.AlphaBlendEnable, true);
                 device.SetRenderState(RenderState.SourceBlend, SlimDX.Direct3D9.Blend.SourceAlpha);             // 5
                 device.SetRenderState(RenderState.DestinationBlend, SlimDX.Direct3D9.Blend.InverseSourceAlpha); // 6
             }

--- a/FDK17プロジェクト/コード/05.DirectShow/CDirectShow.cs
+++ b/FDK17プロジェクト/コード/05.DirectShow/CDirectShow.cs
@@ -1391,13 +1391,6 @@ namespace FDK
 		public const int nインスタンスIDの最大数 = 100;
 		protected static Dictionary<int, CDirectShow> dicインスタンス = new Dictionary<int, CDirectShow>();	// <インスタンスID, そのIDを持つインスタンス>
 
-		public static CDirectShow tインスタンスを返す( int nインスタンスID )
-		{
-			if( CDirectShow.dicインスタンス.ContainsKey( nインスタンスID ) )
-				return CDirectShow.dicインスタンス[ nインスタンスID ];
-
-			return null;
-		}
 		protected static void tインスタンスを登録する( CDirectShow ds )
 		{
 			for( int i = 1; i < CDirectShow.nインスタンスIDの最大数; i++ )


### PR DESCRIPTION
Commit comments provide full details but the short version is that, by avoiding repeated and unnecessary calculations, 挑戦! スペック8段 average frame rate has improved by a further 52% during this round. So, including the work merged in #104, 挑戦! スペック8段 has gone through the following:

| version | min | average | max |
| - | - | - | - |
| 1.2.0 | 15 | 35 | 220 |
| #104 | 304 | 424 | 536 |
| this PR | 460 | 645 | 812 |
