### PR TITLE
Increase FPS approx. 10% by skipping redundant Device calls

### DIFF
--- a/DTXManiaプロジェクト/DTXManiaプロジェクト.csproj
+++ b/DTXManiaプロジェクト/DTXManiaプロジェクト.csproj
@@ -50,6 +50,7 @@
     <NoWarn>0219</NoWarn>
     <UseVSHostingProcess>false</UseVSHostingProcess>
     <Optimize>false</Optimize>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <OutputPath>..\Test\</OutputPath>
@@ -61,6 +62,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>0219</NoWarn>
     <UseVSHostingProcess>true</UseVSHostingProcess>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>TJAPlayer3.manifest</ApplicationManifest>

--- a/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectPreimageパネル.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectPreimageパネル.cs
@@ -63,7 +63,7 @@ namespace DTXMania
 				//this.txセンサ光 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\5_sensor light.png" ), false );
 				this.txプレビュー画像 = null;
 				this.txプレビュー画像がないときの画像 = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\5_preimage default.png" ), false );
-				this.sfAVI画像 = Surface.CreateOffscreenPlain( CDTXMania.app.Device, 0xcc, 0x10d, CDTXMania.app.GraphicsDeviceManager.CurrentSettings.BackBufferFormat, Pool.SystemMemory );
+				this.sfAVI画像 = Surface.CreateOffscreenPlain( CDTXMania.app.Device.UnderlyingDevice, 0xcc, 0x10d, CDTXMania.app.GraphicsDeviceManager.CurrentSettings.BackBufferFormat, Pool.SystemMemory );
 				this.nAVI再生開始時刻 = -1;
 				this.n前回描画したフレーム番号 = -1;
 				this.b動画フレームを作成した = false;

--- a/DTXManiaプロジェクト/コード/ステージ/CActオプションパネル.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/CActオプションパネル.cs
@@ -5,6 +5,8 @@ using System.Drawing;
 using SlimDX.Direct3D9;
 using FDK;
 
+using Device = SampleFramework.DeviceCache;
+
 namespace DTXMania
 {
 	internal class CActオプションパネル : CActivity

--- a/DTXManiaプロジェクト/コード/プラグイン/CPluginHost.cs
+++ b/DTXManiaプロジェクト/コード/プラグイン/CPluginHost.cs
@@ -27,7 +27,7 @@ namespace DTXMania
 		}
 		public Device D3D9Device
 		{
-			get { return (CDTXMania.app != null ) ? CDTXMania.app.Device : null; }
+			get { return (CDTXMania.app != null ) ? CDTXMania.app.Device.UnderlyingDevice : null; }
 		}
 		public Format TextureFormat
 		{

--- a/DTXManiaプロジェクト/コード/全体/CActFlushGPU.cs
+++ b/DTXManiaプロジェクト/コード/全体/CActFlushGPU.cs
@@ -23,7 +23,7 @@ namespace DTXMania
 			{
 				try			// #xxxxx 2012.12.31 yyagi: to prepare flush, first of all, I create q queue to the GPU.
 				{
-					IDirect3DQuery9 = new SlimDX.Direct3D9.Query( CDTXMania.app.Device, QueryType.Occlusion );
+					IDirect3DQuery9 = new SlimDX.Direct3D9.Query( CDTXMania.app.Device.UnderlyingDevice, QueryType.Occlusion );
 				}
 				catch ( Exception e )
 				{

--- a/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
+++ b/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
@@ -283,7 +283,7 @@ namespace DTXMania
 			get;
 			set;
 		}
-		public Device Device
+		public DeviceCache Device
 		{
 			get { return base.GraphicsDeviceManager.Direct3D9.Device; }
 		}

--- a/FDK17プロジェクト/FDK19.csproj
+++ b/FDK17プロジェクト/FDK19.csproj
@@ -34,6 +34,7 @@
     <DefineConstants>TRACE;TEST_CancelEnterCodeInAltEnter2 TEST_Direct3D9Ex_</DefineConstants>
     <Optimize>false</Optimize>
     <DebugType>pdbonly</DebugType>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -45,6 +46,7 @@
     <NoWarn>0219</NoWarn>
     <DefineConstants>TRACE;TEST_ENGLISH_ TEST_Direct3D9Ex_</DefineConstants>
     <Optimize>true</Optimize>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Bass.Net">
@@ -87,6 +89,7 @@
     <Compile Include="コード\01.フレームワーク\Enumeration\Enumeration9.cs" />
     <Compile Include="コード\01.フレームワーク\Properties\Resources.Designer.cs" />
     <Compile Include="コード\01.フレームワーク\Rendering\DeviceCreationException.cs" />
+    <Compile Include="コード\01.フレームワーク\Rendering\DeviceCache.cs" />
     <Compile Include="コード\01.フレームワーク\Rendering\Direct3D9Manager.cs" />
     <Compile Include="コード\01.フレームワーク\Rendering\Enums.cs" />
     <Compile Include="コード\01.フレームワーク\Rendering\GraphicsDeviceManager.cs" />

--- a/FDK17プロジェクト/コード/01.フレームワーク/Rendering/DeviceCache.cs
+++ b/FDK17プロジェクト/コード/01.フレームワーク/Rendering/DeviceCache.cs
@@ -1,0 +1,208 @@
+﻿using System;
+using System.Drawing;
+using SlimDX;
+using SlimDX.Direct3D9;
+
+namespace SampleFramework
+{
+    public sealed class DeviceCache
+    {
+        private readonly Device _device;
+
+        public DeviceCache(Device device)
+        {
+            _device = device;
+        }
+
+        public Device UnderlyingDevice => _device;
+
+        public void Dispose()
+        {
+            _device.Dispose();
+        }
+
+        public object Tag
+        {
+            get => _device.Tag;
+            set => _device.Tag = value;
+        }
+
+        public Result TestCooperativeLevel()
+        {
+            return _device.TestCooperativeLevel();
+        }
+
+        public Result Reset(PresentParameters presentParameters)
+        {
+            return _device.Reset(presentParameters);
+        }
+
+        public Result Clear(ClearFlags clearFlags, in Color4 color, float zdepth, int stencil)
+        {
+            return _device.Clear(clearFlags, color, zdepth, stencil);
+        }
+
+        public Result BeginScene()
+        {
+            return _device.BeginScene();
+        }
+
+        public Result EndScene()
+        {
+            return _device.EndScene();
+        }
+
+        public Result Present()
+        {
+            return _device.Present();
+        }
+
+        public Surface GetBackBuffer(int swapChain, int backBuffer)
+        {
+            return _device.GetBackBuffer(swapChain, backBuffer);
+        }
+
+        public Surface GetRenderTarget(int index)
+        {
+            return _device.GetRenderTarget(index);
+        }
+
+        public Result SetRenderState<T>(RenderState state, T value) where T : Enum
+        {
+            return _device.SetRenderState(state, value);
+        }
+
+        private BlendOperation? _lastBlendOperation;
+        public void SetRenderState(RenderState state, BlendOperation value)
+        {
+            if (state == RenderState.BlendOperation)
+            {
+                if (_lastBlendOperation == value)
+                {
+                    return;
+                }
+
+                _lastBlendOperation = value;
+            }
+
+            _device.SetRenderState(state, value);
+        }
+
+        private Blend? _lastSourceBlend;
+        private Blend? _lastDestinationBlend;
+        public void SetRenderState(RenderState state, Blend value)
+        {
+            if (state == RenderState.SourceBlend)
+            {
+                if (_lastSourceBlend == value)
+                {
+                    return;
+                }
+
+                _lastSourceBlend = value;
+            }
+            else if (state == RenderState.DestinationBlend)
+            {
+                if (_lastDestinationBlend == value)
+                {
+                    return;
+                }
+
+                _lastDestinationBlend = value;
+            }
+
+            _device.SetRenderState(state, value);
+        }
+
+        public Result SetRenderState(RenderState state, bool value)
+        {
+            return _device.SetRenderState(state, value);
+        }
+
+        public Result SetRenderState(RenderState state, int value)
+        {
+            return _device.SetRenderState(state, value);
+        }
+
+        public Result SetTextureStageState(int stage, TextureStage type, TextureOperation textureOperation)
+        {
+            return _device.SetTextureStageState(stage, type, textureOperation);
+        }
+
+        public Result SetTextureStageState(int stage, TextureStage type, int value)
+        {
+            return _device.SetTextureStageState(stage, type, value);
+        }
+
+        public Result SetSamplerState(int sampler, SamplerState type, TextureFilter textureFilter)
+        {
+            return _device.SetSamplerState(sampler, type, textureFilter);
+        }
+
+        public Result SetTransform(TransformState state, in Matrix value)
+        {
+            return _device.SetTransform(state, value);
+        }
+
+        private int? _lastSetTextureSampler;
+        private object _lastSetTextureTexture;
+        public void SetTexture(int sampler, BaseTexture texture)
+        {
+            if ( ReferenceEquals(_lastSetTextureTexture, texture) && _lastSetTextureSampler == sampler)
+            {
+                return;
+            }
+
+            _lastSetTextureSampler = sampler;
+            _lastSetTextureTexture = texture;
+            _device.SetTexture(sampler, texture);
+        }
+
+        public Result SetRenderTarget(int targetIndex, Surface target)
+        {
+            return _device.SetRenderTarget(targetIndex, target);
+        }
+
+        public Result DrawUserPrimitives<T>(PrimitiveType primitiveType, int startIndex, int primitiveCount, in T[] data) where T : struct//, new()
+        {
+            return _device.DrawUserPrimitives(primitiveType, startIndex, primitiveCount, data);
+        }
+
+        public Result DrawUserPrimitives<T>(PrimitiveType primitiveType, int primitiveCount, in T[] data) where T : struct//, new()
+        {
+            return _device.DrawUserPrimitives(primitiveType, primitiveCount, data);
+        }
+
+        public Result StretchRectangle(Surface source, Surface destination, TextureFilter filter)
+        {
+            return _device.StretchRectangle(source, destination, filter);
+        }
+
+        public Result UpdateSurface(Surface source, in Rectangle sourceRectangle, Surface destination, in Point destinationPoint)
+        {
+            return _device.UpdateSurface(source, sourceRectangle, destination, destinationPoint);
+        }
+
+        public Viewport Viewport
+        {
+            get => _device.Viewport;
+            set => _device.Viewport = value;
+        }
+
+        private VertexFormat? _lastVertexFormat;
+        public VertexFormat VertexFormat
+        {
+            get => _device.VertexFormat;
+            set
+            {
+                if (_lastVertexFormat != value)
+                {
+                    _lastVertexFormat = value;
+                    _device.VertexFormat = value;
+                }
+            }
+        }
+
+        public Capabilities Capabilities => _device.Capabilities;
+    }
+}

--- a/FDK17プロジェクト/コード/01.フレームワーク/Rendering/Direct3D9Manager.cs
+++ b/FDK17プロジェクト/コード/01.フレームワーク/Rendering/Direct3D9Manager.cs
@@ -43,7 +43,7 @@ namespace SampleFramework
 #if TEST_Direct3D9Ex
 		public DeviceEx Device							//yyagi
 #else
-		public Device Device
+		public DeviceCache Device
 #endif
 		{
             get;
@@ -121,7 +121,7 @@ namespace SampleFramework
             }
 
             elements.Add(VertexElement.VertexDeclarationEnd);
-            return new VertexDeclaration(Device, elements.ToArray());
+            return new VertexDeclaration(Device.UnderlyingDevice, elements.ToArray());
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace SampleFramework
         /// <returns>The newly created render target surface.</returns>
         public Texture CreateRenderTarget(int width, int height)
         {
-            return new Texture(Device, width, height, 1, Usage.RenderTarget, manager.CurrentSettings.BackBufferFormat, Pool.Default);
+            return new Texture(Device.UnderlyingDevice, width, height, 1, Usage.RenderTarget, manager.CurrentSettings.BackBufferFormat, Pool.Default);
         }
 
         /// <summary>
@@ -141,7 +141,7 @@ namespace SampleFramework
         /// <returns>The newly created resolve target.</returns>
         public Texture CreateResolveTarget()
         {
-            return new Texture(Device, manager.ScreenWidth, manager.ScreenHeight, 1, Usage.RenderTarget, manager.CurrentSettings.BackBufferFormat, Pool.Default);
+            return new Texture(Device.UnderlyingDevice, manager.ScreenWidth, manager.ScreenHeight, 1, Usage.RenderTarget, manager.CurrentSettings.BackBufferFormat, Pool.Default);
         }
 
         /// <summary>

--- a/FDK17プロジェクト/コード/01.フレームワーク/Rendering/GraphicsDeviceManager.cs
+++ b/FDK17プロジェクト/コード/01.フレームワーク/Rendering/GraphicsDeviceManager.cs
@@ -29,6 +29,7 @@ using SlimDX;
 using SlimDX.Direct3D9;
 using SlimDX.DXGI;
 using System.Diagnostics;
+
 namespace SampleFramework
 {
     /// <summary>
@@ -514,9 +515,9 @@ namespace SampleFramework
 				}
 				Direct3D9.Device.MaximumFrameLatency = 1;
 #else
-				Direct3D9.Device = new SlimDX.Direct3D9.Device( Direct3D9Object, CurrentSettings.Direct3D9.AdapterOrdinal,
+				Direct3D9.Device = new DeviceCache( new SlimDX.Direct3D9.Device( Direct3D9Object, CurrentSettings.Direct3D9.AdapterOrdinal,
 					CurrentSettings.Direct3D9.DeviceType, game.Window.Handle,
-					CurrentSettings.Direct3D9.CreationFlags, CurrentSettings.Direct3D9.PresentParameters );
+					CurrentSettings.Direct3D9.CreationFlags, CurrentSettings.Direct3D9.PresentParameters ) );
 #endif
 				if ( Result.Last == SlimDX.Direct3D9.ResultCode.DeviceLost )
 				{

--- a/FDK17プロジェクト/コード/04.グラフィック/CTexture.cs
+++ b/FDK17プロジェクト/コード/04.グラフィック/CTexture.cs
@@ -8,6 +8,8 @@ using System.Diagnostics;
 using SlimDX;
 using SlimDX.Direct3D9;
 
+using Device = SampleFramework.DeviceCache;
+
 namespace FDK
 {
     public class CTexture : IDisposable
@@ -134,7 +136,7 @@ namespace FDK
                     bitmap.Save(stream, ImageFormat.Bmp);
                     stream.Seek(0L, SeekOrigin.Begin);
                     int colorKey = unchecked((int)0xFF000000);
-                    this.texture = Texture.FromStream(device, stream, this.szテクスチャサイズ.Width, this.szテクスチャサイズ.Height, 1, Usage.None, format, poolvar, Filter.Point, Filter.None, colorKey);
+                    this.texture = Texture.FromStream(device.UnderlyingDevice, stream, this.szテクスチャサイズ.Width, this.szテクスチャサイズ.Height, 1, Usage.None, format, poolvar, Filter.Point, Filter.None, colorKey);
                 }
             }
             catch (Exception e)
@@ -227,7 +229,7 @@ namespace FDK
 						pool = poolvar;
 #endif
                         // 中で更にメモリ読み込みし直していて無駄なので、Streamを使うのは止めたいところ
-                        this.texture = Texture.FromStream(device, stream, n幅, n高さ, 1, usage, format, pool, Filter.Point, Filter.None, 0);
+                        this.texture = Texture.FromStream(device.UnderlyingDevice, stream, n幅, n高さ, 1, usage, format, pool, Filter.Point, Filter.None, 0);
                     }
                 }
             }
@@ -286,7 +288,7 @@ namespace FDK
                 //				lock ( lockobj )
                 //				{
                 //Trace.TraceInformation( "CTexture() start: " );
-                this.texture = Texture.FromMemory(device, txData, this.sz画像サイズ.Width, this.sz画像サイズ.Height, 1, Usage.None, format, pool, Filter.Point, Filter.None, colorKey);
+                this.texture = Texture.FromMemory(device.UnderlyingDevice, txData, this.sz画像サイズ.Width, this.sz画像サイズ.Height, 1, Usage.None, format, pool, Filter.Point, Filter.None, colorKey);
                 //Trace.TraceInformation( "CTexture() end:   " );
                 //				}
             }
@@ -327,7 +329,7 @@ namespace FDK
 #if TEST_Direct3D9Ex
 					this.texture = new Texture( device, tw, this.sz画像サイズ.Height, 1, Usage.Dynamic, format, Pool.Default );
 #else
-                    this.texture = new Texture(device, this.sz画像サイズ.Width, this.sz画像サイズ.Height, 1, Usage.None, format, pool);
+                    this.texture = new Texture(device.UnderlyingDevice, this.sz画像サイズ.Width, this.sz画像サイズ.Height, 1, Usage.None, format, pool);
 #endif
                     BitmapData srcBufData = bitmap.LockBits(new Rectangle(0, 0, this.sz画像サイズ.Width, this.sz画像サイズ.Height), ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
                     DataRectangle destDataRectangle = texture.LockRectangle(0, LockFlags.Discard);  // None
@@ -480,7 +482,7 @@ namespace FDK
 
                 device.SetTexture(0, this.texture);
                 device.VertexFormat = TransformedColoredTexturedVertex.Format;
-                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 0, 2, this.cvTransformedColoredVertexies);
+                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 0, 2, in this.cvTransformedColoredVertexies);
                 //-----------------
                 #endregion
             }
@@ -543,7 +545,7 @@ namespace FDK
 
                 device.SetTexture(0, this.texture);
                 device.VertexFormat = PositionColoredTexturedVertex.Format;
-                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, this.cvPositionColoredVertexies);
+                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, in this.cvPositionColoredVertexies);
                 //-----------------
                 #endregion
             }
@@ -609,7 +611,7 @@ namespace FDK
 
                 device.SetTexture(0, this.texture);
                 device.VertexFormat = TransformedColoredTexturedVertex.Format;
-                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 0, 2, this.cvTransformedColoredVertexies);
+                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 0, 2, in this.cvTransformedColoredVertexies);
                 //-----------------
                 #endregion
             }
@@ -672,7 +674,7 @@ namespace FDK
 
                 device.SetTexture(0, this.texture);
                 device.VertexFormat = PositionColoredTexturedVertex.Format;
-                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, this.cvPositionColoredVertexies);
+                device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, in this.cvPositionColoredVertexies);
                 //-----------------
                 #endregion
             }
@@ -742,7 +744,7 @@ namespace FDK
 
             device.SetTexture(0, this.texture);
             device.VertexFormat = TransformedColoredTexturedVertex.Format;
-            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, this.cvTransformedColoredVertexies);
+            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, in this.cvTransformedColoredVertexies);
         }
         public void t2D上下反転描画(Device device, Point pt)
         {
@@ -841,7 +843,7 @@ namespace FDK
             device.SetTransform(TransformState.World, mat);
             device.SetTexture(0, this.texture);
             device.VertexFormat = PositionColoredTexturedVertex.Format;
-            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, this.cvPositionColoredVertexies);
+            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, in this.cvPositionColoredVertexies);
         }
 
         public void t3D左上基準描画(Device device, Matrix mat)
@@ -908,7 +910,7 @@ namespace FDK
             device.SetTransform(TransformState.World, mat);
             device.SetTexture(0, this.texture);
             device.VertexFormat = PositionColoredTexturedVertex.Format;
-            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, this.cvPositionColoredVertexies);
+            device.DrawUserPrimitives(PrimitiveType.TriangleStrip, 2, in this.cvPositionColoredVertexies);
         }
 
         #region [ IDisposable 実装 ]
@@ -998,11 +1000,14 @@ namespace FDK
         }
         private Size t指定されたサイズを超えない最適なテクスチャサイズを返す(Device device, Size sz指定サイズ)
         {
-            bool b条件付きでサイズは２の累乗でなくてもOK = (device.Capabilities.TextureCaps & TextureCaps.NonPow2Conditional) != 0;
-            bool bサイズは２の累乗でなければならない = (device.Capabilities.TextureCaps & TextureCaps.Pow2) != 0;
-            bool b正方形でなければならない = (device.Capabilities.TextureCaps & TextureCaps.SquareOnly) != 0;
-            int n最大幅 = device.Capabilities.MaxTextureWidth;
-            int n最大高 = device.Capabilities.MaxTextureHeight;
+            var deviceCapabilities = device.Capabilities;
+            var deviceCapabilitiesTextureCaps = deviceCapabilities.TextureCaps;
+
+            bool b条件付きでサイズは２の累乗でなくてもOK = (deviceCapabilitiesTextureCaps & TextureCaps.NonPow2Conditional) != 0;
+            bool bサイズは２の累乗でなければならない = (deviceCapabilitiesTextureCaps & TextureCaps.Pow2) != 0;
+            bool b正方形でなければならない = (deviceCapabilitiesTextureCaps & TextureCaps.SquareOnly) != 0;
+            int n最大幅 = deviceCapabilities.MaxTextureWidth;
+            int n最大高 = deviceCapabilities.MaxTextureHeight;
             var szサイズ = new Size(sz指定サイズ.Width, sz指定サイズ.Height);
 
             if (bサイズは２の累乗でなければならない && !b条件付きでサイズは２の累乗でなくてもOK)

--- a/FDK17プロジェクト/コード/04.グラフィック/CTextureAutofold.cs
+++ b/FDK17プロジェクト/コード/04.グラフィック/CTextureAutofold.cs
@@ -8,6 +8,8 @@ using System.Diagnostics;
 using SlimDX;
 using SlimDX.Direct3D9;
 
+using Device = SampleFramework.DeviceCache;
+
 namespace FDK
 {
 	/// <summary>


### PR DESCRIPTION
Quoting from the comment for simplicity: "Increase FPS approx. 10% by skipping redundant SetRenderState, set VertexFormat, and SetTexture calls to the SlimDX D3D9 Device object. This is performed via a proxy which adds overhead to Device methods other than these, and that could be avoided with more invasive changes, but this keeps it clean for now and still provides a net win. It also sets up a good point in the code to start narrowing the SlimDX surface area in prep for either library upgrades or migration off to something like SharpDX."

Note that I originally performed this work on top of my current develop line, which already has taken merges for all outstanding PRs, but I've cherry-picked onto master for opening this PR. These changes are nowhere near those of the other PRs, so they should apply quite independently. That said, it would be safest to merge PRs in the order they were opened.