### PR TITLE
選曲画面の微調整

### DIFF
--- a/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelect曲リスト.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelect曲リスト.cs
@@ -265,6 +265,7 @@ namespace DTXMania
 				this.r現在選択中の曲 = this.r現在選択中の曲.list子リスト[ 0 ];
 				this.t現在選択中の曲を元に曲バーを再構成する();
 				this.t選択曲が変更された(false);									// #27648 項目数変更を反映させる
+				this.b選択曲が変更された = true;
 			}
 			return ret;
 		}
@@ -298,6 +299,7 @@ namespace DTXMania
 				this.r現在選択中の曲 = this.r現在選択中の曲.r親ノード;
 				this.t現在選択中の曲を元に曲バーを再構成する();
 				this.t選択曲が変更された(false);									// #27648 項目数変更を反映させる
+				this.b選択曲が変更された = true;
 			}
 			return ret;
 		}
@@ -315,6 +317,7 @@ namespace DTXMania
 			{
 				this.n目標のスクロールカウンタ += 100;
 			}
+			this.b選択曲が変更された = true;
 		}
 		public void t前に移動()
 		{
@@ -322,6 +325,7 @@ namespace DTXMania
 			{
 				this.n目標のスクロールカウンタ -= 100;
 			}
+			this.b選択曲が変更された = true;
 		}
 		public void t難易度レベルをひとつ進める()
 		{

--- a/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelect曲リスト.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelect曲リスト.cs
@@ -778,6 +778,286 @@ namespace DTXMania
 
 
 
+            if ( !this.b登場アニメ全部完了 )
+			{
+				#region [ (1) 登場アニメフェーズの進行。]
+				//-----------------
+				for( int i = 0; i < 13; i++ )	// パネルは全13枚。
+				{
+					this.ct登場アニメ用[ i ].t進行();
+
+					if( this.ct登場アニメ用[ i ].b終了値に達した )
+						this.ct登場アニメ用[ i ].t停止();
+				}
+
+				// 全部の進行が終わったら、this.b登場アニメ全部完了 を true にする。
+
+				this.b登場アニメ全部完了 = true;
+				for( int i = 0; i < 13; i++ )	// パネルは全13枚。
+				{
+					if( this.ct登場アニメ用[ i ].b進行中 )
+					{
+						this.b登場アニメ全部完了 = false;	// まだ進行中のアニメがあるなら false のまま。
+						break;
+					}
+				}
+				//-----------------
+				#endregion
+			}
+			else
+			{
+				#region [ (2) 通常フェーズの進行。]
+				//-----------------
+				long n現在時刻 = CSound管理.rc演奏用タイマ.n現在時刻;
+				
+				if( n現在時刻 < this.nスクロールタイマ )	// 念のため
+					this.nスクロールタイマ = n現在時刻;
+
+				const int nアニメ間隔 = 2;
+				while( ( n現在時刻 - this.nスクロールタイマ ) >= nアニメ間隔 )
+				{
+					int n加速度 = 1;
+					int n残距離 = Math.Abs( (int) ( this.n目標のスクロールカウンタ - this.n現在のスクロールカウンタ ) );
+
+                    #region [ 残距離が遠いほどスクロールを速くする（＝n加速度を多くする）。]
+                    //-----------------
+                    if (n残距離 <= 10)
+                    {
+                        n加速度 = 1;
+                    }
+                    else if ( n残距離 <= 100 )
+					{
+						n加速度 = 2;
+					}
+					else if( n残距離 <= 300 )
+					{
+						n加速度 = 3;
+					}
+					else if( n残距離 <= 500 )
+					{
+						n加速度 = 4;
+					}
+					else
+					{
+						n加速度 = 8;
+					}
+					//-----------------
+					#endregion
+
+					#region [ 加速度を加算し、現在のスクロールカウンタを目標のスクロールカウンタまで近づける。 ]
+					//-----------------
+					if( this.n現在のスクロールカウンタ < this.n目標のスクロールカウンタ )		// (A) 正の方向に未達の場合：
+					{
+						this.n現在のスクロールカウンタ += n加速度;								// カウンタを正方向に移動する。
+
+						if( this.n現在のスクロールカウンタ > this.n目標のスクロールカウンタ )
+							this.n現在のスクロールカウンタ = this.n目標のスクロールカウンタ;	// 到着！スクロール停止！
+					}
+
+					else if( this.n現在のスクロールカウンタ > this.n目標のスクロールカウンタ )	// (B) 負の方向に未達の場合：
+					{
+						this.n現在のスクロールカウンタ -= n加速度;								// カウンタを負方向に移動する。
+
+						if( this.n現在のスクロールカウンタ < this.n目標のスクロールカウンタ )	// 到着！スクロール停止！
+							this.n現在のスクロールカウンタ = this.n目標のスクロールカウンタ;
+					}
+					//-----------------
+					#endregion
+
+					if( this.n現在のスクロールカウンタ >= 100 )		// １行＝100カウント。
+					{
+						#region [ パネルを１行上にシフトする。]
+						//-----------------
+
+						// 選択曲と選択行を１つ下の行に移動。
+
+						this.r現在選択中の曲 = this.r次の曲( this.r現在選択中の曲 );
+						this.n現在の選択行 = ( this.n現在の選択行 + 1 ) % 13;
+
+
+						// 選択曲から７つ下のパネル（＝新しく最下部に表示されるパネル。消えてしまう一番上のパネルを再利用する）に、新しい曲の情報を記載する。
+
+						C曲リストノード song = this.r現在選択中の曲;
+						for( int i = 0; i < 7; i++ )
+							song = this.r次の曲( song );
+
+						int index = ( this.n現在の選択行 + 7 ) % 13;	// 新しく最下部に表示されるパネルのインデックス（0～12）。
+						this.stバー情報[ index ].strタイトル文字列 = song.strタイトル;
+                        this.stバー情報[index].ForeColor = song.ForeColor;
+                        this.stバー情報[index].BackColor = song.BackColor;
+                        this.stバー情報[ index ].strジャンル = song.strジャンル;
+                        this.stバー情報[ index ].strサブタイトル = song.strサブタイトル;
+                        this.stバー情報[ index ].ar難易度 = song.nLevel;
+                        this.t曲名バーの生成(index, this.stバー情報[index].strタイトル文字列, this.stバー情報[index].ForeColor, this.stバー情報[index].BackColor);
+                        for ( int f = 0; f < 5; f++ )
+                        {
+                            if( song.arスコア[ f ] != null )
+                                this.stバー情報[ index ].b分岐 = song.arスコア[ f ].譜面情報.b譜面分岐;
+                        }
+
+
+						// stバー情報[] の内容を1行ずつずらす。
+						
+						C曲リストノード song2 = this.r現在選択中の曲;
+						for( int i = 0; i < 5; i++ )
+							song2 = this.r前の曲( song2 );
+
+						for( int i = 0; i < 13; i++ )
+						{
+							int n = ( ( ( this.n現在の選択行 - 5 ) + i ) + 13 ) % 13;
+							this.stバー情報[ n ].eバー種別 = this.e曲のバー種別を返す( song2 );
+							song2 = this.r次の曲( song2 );
+                            this.stバー情報[ i ].txタイトル = this.t曲名テクスチャを生成する( this.stバー情報[ i ].strタイトル文字列, this.stバー情報[i].ForeColor, this.stバー情報[i].BackColor);
+
+						}
+
+						
+						// 新しく最下部に表示されるパネル用のスキル値を取得。
+
+						for( int i = 0; i < 3; i++ )
+							this.stバー情報[ index ].nスキル値[ i ] = (int) song.arスコア[ this.n現在のアンカ難易度レベルに最も近い難易度レベルを返す( song ) ].譜面情報.最大スキル[ i ];
+
+
+						// 1行(100カウント)移動完了。
+
+						this.n現在のスクロールカウンタ -= 100;
+						this.n目標のスクロールカウンタ -= 100;
+
+						this.t選択曲が変更された(false);				// スクロールバー用に今何番目を選択しているかを更新
+
+
+
+						if( this.n目標のスクロールカウンタ == 0 )
+							CDTXMania.stage選曲.t選択曲変更通知();		// スクロール完了＝選択曲変更！
+
+						//-----------------
+						#endregion
+					}
+					else if( this.n現在のスクロールカウンタ <= -100 )
+					{
+						#region [ パネルを１行下にシフトする。]
+						//-----------------
+
+						// 選択曲と選択行を１つ上の行に移動。
+
+						this.r現在選択中の曲 = this.r前の曲( this.r現在選択中の曲 );
+						this.n現在の選択行 = ( ( this.n現在の選択行 - 1 ) + 13 ) % 13;
+
+
+						// 選択曲から５つ上のパネル（＝新しく最上部に表示されるパネル。消えてしまう一番下のパネルを再利用する）に、新しい曲の情報を記載する。
+
+						C曲リストノード song = this.r現在選択中の曲;
+						for( int i = 0; i < 5; i++ )
+							song = this.r前の曲( song );
+
+						int index = ( ( this.n現在の選択行 - 5 ) + 13 ) % 13;	// 新しく最上部に表示されるパネルのインデックス（0～12）。
+						this.stバー情報[ index ].strタイトル文字列 = song.strタイトル;
+                        this.stバー情報[index].ForeColor = song.ForeColor;
+                        this.stバー情報[index].BackColor = song.BackColor;
+                        this.stバー情報[ index ].strサブタイトル = song.strサブタイトル;
+                        this.stバー情報[ index ].strジャンル = song.strジャンル;
+                        this.stバー情報[ index ].ar難易度 = song.nLevel;
+                        this.t曲名バーの生成(index, this.stバー情報[index].strタイトル文字列, this.stバー情報[index].ForeColor, this.stバー情報[index].BackColor);
+                        for ( int f = 0; f < 5; f++ )
+                        {
+                            if( song.arスコア[ f ] != null )
+                                this.stバー情報[ index ].b分岐 = song.arスコア[ f ].譜面情報.b譜面分岐;
+                        }
+
+						// stバー情報[] の内容を1行ずつずらす。
+						
+						C曲リストノード song2 = this.r現在選択中の曲;
+						for( int i = 0; i < 5; i++ )
+							song2 = this.r前の曲( song2 );
+
+						for( int i = 0; i < 13; i++ )
+						{
+							int n = ( ( ( this.n現在の選択行 - 5 ) + i ) + 13 ) % 13;
+							this.stバー情報[ n ].eバー種別 = this.e曲のバー種別を返す( song2 );
+							song2 = this.r次の曲( song2 );
+                            this.stバー情報[ i ].txタイトル = this.t曲名テクスチャを生成する( this.stバー情報[ i ].strタイトル文字列, this.stバー情報[i].ForeColor, this.stバー情報[i].BackColor);
+						}
+
+		
+						// 新しく最上部に表示されるパネル用のスキル値を取得。
+						
+						for( int i = 0; i < 3; i++ )
+							this.stバー情報[ index ].nスキル値[ i ] = (int) song.arスコア[ this.n現在のアンカ難易度レベルに最も近い難易度レベルを返す( song ) ].譜面情報.最大スキル[ i ];
+
+
+						// 1行(100カウント)移動完了。
+
+						this.n現在のスクロールカウンタ += 100;
+						this.n目標のスクロールカウンタ += 100;
+
+						this.t選択曲が変更された(false);				// スクロールバー用に今何番目を選択しているかを更新
+
+                        if( this.tx選択している曲の曲名 != null )
+                        {
+                            this.tx選択している曲の曲名.Dispose();
+                            this.tx選択している曲の曲名 = null;
+                        }
+                        if( this.tx選択している曲のサブタイトル != null )
+                        {
+                            this.tx選択している曲のサブタイトル.Dispose();
+                            this.tx選択している曲のサブタイトル = null;
+                        }
+						
+						if( this.n目標のスクロールカウンタ == 0 )
+							CDTXMania.stage選曲.t選択曲変更通知();		// スクロール完了＝選択曲変更！
+						//-----------------
+						#endregion
+					}
+
+                    if(this.b選択曲が変更された && n現在のスクロールカウンタ==0)
+                    {
+                        if (this.tx選択している曲の曲名 != null)
+                        {
+                            this.tx選択している曲の曲名.Dispose();
+                            this.tx選択している曲の曲名 = null;
+                            this.b選択曲が変更された = false;
+                        }
+                        if (this.tx選択している曲のサブタイトル != null)
+                        {
+                            this.tx選択している曲のサブタイトル.Dispose();
+                            this.tx選択している曲のサブタイトル = null;
+                            this.b選択曲が変更された = false;
+                        }
+                    }
+					this.nスクロールタイマ += nアニメ間隔;
+				}
+				//-----------------
+				#endregion
+			}
+
+
+			// 描画。
+
+			if( this.r現在選択中の曲 == null )
+			{
+				#region [ 曲が１つもないなら「Songs not found.」を表示してここで帰れ。]
+				//-----------------
+				if ( bIsEnumeratingSongs )
+				{
+					if ( this.txEnumeratingSongs != null )
+					{
+						this.txEnumeratingSongs.t2D描画( CDTXMania.app.Device, 320, 160 );
+					}
+				}
+				else
+				{
+					if ( this.txSongNotFound != null )
+						this.txSongNotFound.t2D描画( CDTXMania.app.Device, 320, 160 );
+				}
+				//-----------------
+				#endregion
+
+				return 0;
+			}
+
+            int i選曲バーX座標 = 673; //選曲バーの座標用
+            int i選択曲バーX座標 = 665; //選択曲バーの座標用
+
 			if( !this.b登場アニメ全部完了 )
 			{
                 if( this.n現在のスクロールカウンタ == 0 )
@@ -966,7 +1246,7 @@ namespace DTXMania
 		
 					{
                         // (B) スクロール中の選択曲バー、またはその他のバーの描画。
-
+                        
                         #region [ バーテクスチャを描画。]
                         //-----------------
                         if (n現在のスクロールカウンタ != 0)
@@ -975,17 +1255,18 @@ namespace DTXMania
                             this.tジャンル別選択されていない曲バーの描画(xAnime, CDTXMania.Skin.SongSelect_Overall_Y, this.stバー情報[nパネル番号].strジャンル);
                         if (this.stバー情報[nパネル番号].b分岐[CDTXMania.stage選曲.n現在選択中の曲の難易度] == true && n見た目の行番号 != 5)
                             CDTXMania.Tx.SongSelect_Branch.t2D描画(CDTXMania.app.Device, xAnime + 66, CDTXMania.Skin.SongSelect_Overall_Y - 5);
-						//-----------------
-						#endregion
-						#region [ タイトル名テクスチャを描画。]
-                        if( this.stバー情報[ nパネル番号 ].txタイトル != null && n見た目の行番号 != 5)
-                        {
-                            if (n現在のスクロールカウンタ != 0)
-                                this.stバー情報[ nパネル番号 ].txタイトル.t2D描画( CDTXMania.app.Device, xAnime + 28, CDTXMania.Skin.SongSelect_Overall_Y+23);
-                            else if (n見た目の行番号 != 5)
-                                this.stバー情報[nパネル番号].txタイトル.t2D描画(CDTXMania.app.Device, xAnime + 28, CDTXMania.Skin.SongSelect_Overall_Y + 23);
-                        }
+                        //-----------------
+                        #endregion
 
+                        #region [ タイトル名テクスチャを描画。]
+
+                        if (n現在のスクロールカウンタ != 0)
+                            this.stバー情報[ nパネル番号 ].txタイトル.t2D描画( CDTXMania.app.Device, xAnime + 28, CDTXMania.Skin.SongSelect_Overall_Y+23);
+                        else if (n見た目の行番号 != 5)
+                            this.stバー情報[nパネル番号].txタイトル.t2D描画(CDTXMania.app.Device, xAnime + 28, CDTXMania.Skin.SongSelect_Overall_Y + 23);
+                        
+                        #endregion
+                        
                         if( this.stバー情報[ nパネル番号 ].ar難易度 != null )
                         {
                             int nX補正 = 0;
@@ -993,10 +1274,9 @@ namespace DTXMania
                                 nX補正 = -6;
                             this.t小文字表示( xAnime + 65 + nX補正, 559, this.stバー情報[ nパネル番号 ].ar難易度[ CDTXMania.stage選曲.n現在選択中の曲の難易度 ].ToString() );
                         }
-						//-----------------
-						#endregion
+						//-----------------						
 					}
-
+                    #endregion
 				}
 
                 if( this.n現在のスクロールカウンタ == 0 )
@@ -1149,20 +1429,18 @@ namespace DTXMania
 
                     if( ( i == 5 ) && ( this.n現在のスクロールカウンタ == 0 ) )
 					{
-						// (A) スクロールが停止しているときの選択曲バーの描画。
+                        // (A) スクロールが停止しているときの選択曲バーの描画。
 
-						#region [ タイトル名テクスチャを描画。]
-						//-----------------
-                        if( this.stバー情報[ nパネル番号 ].strタイトル文字列 != "" && this.stバー情報[ nパネル番号 ].strタイトル文字列 != null && this.tx選択している曲の曲名 == null )
+                        #region [ タイトル名テクスチャを描画。]
+                        //-----------------
+                        if (this.stバー情報[nパネル番号].strタイトル文字列 != "" &&  this.tx選択している曲の曲名 == null)
                             this.tx選択している曲の曲名 = this.t曲名テクスチャを生成する(this.stバー情報[nパネル番号].strタイトル文字列, Color.White, Color.Black);
-                        if ( this.stバー情報[ nパネル番号 ].strサブタイトル != "" && this.stバー情報[ nパネル番号 ].strサブタイトル != null && this.tx選択している曲のサブタイトル == null )
+                        if ( this.stバー情報[ nパネル番号 ].strサブタイトル != "" && this.tx選択している曲のサブタイトル == null )
                             this.tx選択している曲のサブタイトル = this.tサブタイトルテクスチャを生成する( this.stバー情報[ nパネル番号 ].strサブタイトル );
-
-
 
                         //サブタイトルがあったら700
 
-                        if( this.tx選択している曲のサブタイトル != null )
+                        if ( this.tx選択している曲のサブタイトル != null )
                         {
                             int nサブタイY = (int)(CDTXMania.Skin.SongSelect_Overall_Y + 460 - (this.tx選択している曲のサブタイトル.sz画像サイズ.Height * this.tx選択している曲のサブタイトル.vc拡大縮小倍率.Y ));
 							this.tx選択している曲のサブタイトル.t2D描画( CDTXMania.app.Device, 707, nサブタイY );
@@ -1189,7 +1467,6 @@ namespace DTXMania
 
 				}
 				//-----------------
-				#endregion
 			}
 			#region [ スクロール地点の計算(描画はCActSelectShowCurrentPositionにて行う) #27648 ]
 			int py;
@@ -1220,6 +1497,10 @@ namespace DTXMania
                 if( CDTXMania.Tx.SongSelect_GenreText != null )
                     CDTXMania.Tx.SongSelect_GenreText.t2D描画( CDTXMania.app.Device, 496, CDTXMania.Skin.SongSelect_Overall_Y-64, new Rectangle( 0, 60 * this.nStrジャンルtoNum( this.r現在選択中の曲.strジャンル ), 288, 60 ) );
             }
+
+
+
+
 			return 0;
 		}
 		
@@ -1333,6 +1614,7 @@ namespace DTXMania
 			}
 		}
 
+        public bool b選択曲が変更された = true;
 		private bool b登場アニメ全部完了;
 		private Color color文字影 = Color.FromArgb( 0x40, 10, 10, 10 );
 		private CCounter[] ct登場アニメ用 = new CCounter[ 13 ];

--- a/DTXManiaプロジェクト/コード/全体/CSkin.cs
+++ b/DTXManiaプロジェクト/コード/全体/CSkin.cs
@@ -978,6 +978,13 @@ namespace DTXMania
 
                             #region 新・SkinConfig
                             #region SongSelect
+                            else if (strCommand == "SongSelect_Overall_Y")
+                            {
+                                if (int.Parse(strParam) != 0)
+                                {
+                                    SongSelect_Overall_Y = int.Parse(strParam);
+                                }
+                            }
                             else if (strCommand == "SongSelect_NamePlate_X")
                             {
                                 string[] strSplit = strParam.Split(',');
@@ -1785,9 +1792,10 @@ namespace DTXMania
         #region General
         public string Skin_Name = "Unknown";
         public string Skin_Version = "Unknown";
-        public string Skin_Creator = "Unknown";
+        public string Skin_Crea tor = "Unknown";
         #endregion
         #region SongSelect
+        public int SongSelect_Overall_Y = 123;
         public int[] SongSelect_NamePlate_X = new int[] { 60, 950 };
         public int[] SongSelect_NamePlate_Y = new int[] { 650, 650 };
         public int[] SongSelect_Auto_X = new int[] { 60, 950 };


### PR DESCRIPTION
リバートしたリクエストを使わないと、不具合が出るかもしれない(一度マージしたリクエストは送れない模様)
大まかな変更点としては
・何故か一部必要な描画処理が消えていたので修正
・選択曲および非選択局バー関連のものをSkinConfigで高さ調整できるように(初期値の見直し)
・非選択時のタイトル文字描画がおかしかったのを修正
・選択中のバータイトルの生成タイミングを見直し、生成回数が最小限で済むようにする(メモリに優しく)