### PR TITLE
連打ノーツ、連打ノーツ文字の調整と色変化(仮)

### DIFF
--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
@@ -1786,53 +1786,78 @@ namespace DTXMania
                             }
                         }
 
+                        //kairera0467氏 の TJAPlayer2forPC のコードを参考にし、打数に応じて色を変える(打数の変更以外はほとんどそのまんま) ろみゅ～？ 2018/8/20
+                        float f減少するカラー = pChip.nRollCount < 5 ? 1.0f - ((0.95f / 5) * pChip.nRollCount) : 0.05f; //仮で5打
+                        float f末端ノーツのテクスチャ位置調整=65f;
 
-                        if ( pChip.nチャンネル番号 == 0x15 )
+                        if ( pChip.nチャンネル番号 == 0x15 ) //連打(小)
                         {
-                            //x = ( x + 10 ) - ( ( int ) ( ( 130.0 * pChip.dbチップサイズ倍率 ) / 2.0 ) );
                             int index = x末端 - x; //連打の距離
-                            if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
+                            if ( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
                             {
-                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = index - 65;
-                                CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x + 65, y, new Rectangle( 780, 0, 1, 130 ) );
+                                #region[末端をテクスチャ側で中央に持ってくる場合の方式]
+                                
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f, f減少するカラー, f減少するカラー);
+                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = (index - 65.0f + f末端ノーツのテクスチャ位置調整+1) / 128.0f;
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x + 64, y, new Rectangle(781, 0, 128, 130));
                                 CDTXMania.Tx.Notes.vc拡大縮小倍率.X = 1.0f;
-                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x末端, y, 0, new Rectangle(910, 0, 130, 130));
-                                CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, 0, new Rectangle( 650, num9, 130, 130 ) );
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x末端, y, 0, new Rectangle(910, num9, 130, 130));
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f, 1.0f, 1.0f); //先端シンボルは色を変えない
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x, y, 0, new Rectangle(650, num9, 130, 130));
+                                
+                                #endregion
+                                #region[末端をテクスチャ側でつなげる場合の方式]
+                                /*
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f,f減少するカラー, f減少するカラー);
+                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = (index - 65.0f + f末端ノーツのテクスチャ位置調整+1) / 128.0f;
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x + 64, y, new Rectangle(781, 0, 128, 130));
+                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = 1.0f;
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x末端 + f末端ノーツのテクスチャ位置調整, y, 0, new Rectangle(910, num9, 130, 130));
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f, 1.0f, 1.0f); //先端シンボルは色を変えない
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x, y, 0, new Rectangle(650, num9, 130, 130));
+                                */
+                                #endregion
                             }
-
-                            CDTXMania.Tx.SenNotes.vc拡大縮小倍率.X = index - 34;
+                            CDTXMania.Tx.SenNotes.vc拡大縮小倍率.X = index - 44;
                             CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x + 90, y + nSenotesY, new Rectangle( 60, 240, 1, 30 ) );
                             CDTXMania.Tx.SenNotes.vc拡大縮小倍率.X = 1.0f;
                             CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x, y + nSenotesY, new Rectangle(0, 30 * pChip.nSenote, 136, 30));
                             CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x + 30, y + nSenotesY, new Rectangle(0, 240, 60, 30));
-                            //CDTXMania.act文字コンソール.tPrint( x + 60, y + 140, C文字コンソール.Eフォント種別.白, pChip.nSenote.ToString() );
-                            //CDTXMania.act文字コンソール.tPrint(x, y - 58, C文字コンソール.Eフォント種別.白, pChip.dbBPM.ToString());
-                            //CDTXMania.act文字コンソール.tPrint(x, y - 42, C文字コンソール.Eフォント種別.白, pChip.dbSCROLL.ToString());
-                            //CDTXMania.act文字コンソール.tPrint(x, y - 26, C文字コンソール.Eフォント種別.白, pChip.n発声時刻ms.ToString());
-                            //CDTXMania.act文字コンソール.tPrint(x, y - 10, C文字コンソール.Eフォント種別.白, pChip.nノーツ終了時刻ms.ToString());
                         }
                         if( pChip.nチャンネル番号 == 0x16 )
                         {
-                            //x = ( x + 10 ) - ( ( int ) ( ( 130.0 * pChip.dbチップサイズ倍率 ) / 2.0 ) );
                             int index = x末端 - x; //連打の距離
 
                             if( CDTXMania.ConfigIni.eSTEALTH != Eステルスモード.DORON )
                             {
-                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = index - 65;
-                                CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x + 65, y, new Rectangle( 1170, 0, 1, 130 ) );
+                                #region[末端をテクスチャ側で中央に持ってくる場合の方式]
+                                
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f, f減少するカラー, f減少するカラー);
+                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = (index - 65.0f + f末端ノーツのテクスチャ位置調整+1) / 128f;
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x + 64, y, new Rectangle(1171, 0, 128, 130));
                                 CDTXMania.Tx.Notes.vc拡大縮小倍率.X = 1.0f;
                                 CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x末端, y, 0, new Rectangle(1300, num9, 130, 130));
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f, 1.0f, 1.0f); //先端シンボルは色を変えない
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x, y, new Rectangle(1040, num9, 130, 130));
+                                
+                                #endregion
+                                #region[末端をテクスチャ側でつなげる場合の方式]
+                                /*
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f,f減少するカラー , f減少するカラー);
+                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = (index - 65 + f末端ノーツのテクスチャ位置調整+1) /128f;
+                                CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x + 64, y, new Rectangle( 1171, 0, 128, 130 ) );
+                                CDTXMania.Tx.Notes.vc拡大縮小倍率.X = 1.0f;
+                                CDTXMania.Tx.Notes.t2D描画(CDTXMania.app.Device, x末端 + f末端ノーツのテクスチャ位置調整, y, 0, new Rectangle(1300, num9, 130, 130));
+                                CDTXMania.Tx.Notes.color4 = new Color4(1.0f, 1.0f, 1.0f); //先端シンボルは色を変えない
                                 CDTXMania.Tx.Notes.t2D描画( CDTXMania.app.Device, x, y, new Rectangle( 1040, num9, 130, 130 ) );
+                                */
+                                #endregion
                             }
-
-                            CDTXMania.Tx.SenNotes.vc拡大縮小倍率.X = index - 60;
+                            CDTXMania.Tx.SenNotes.vc拡大縮小倍率.X = index - 70;
                             CDTXMania.Tx.SenNotes.t2D描画( CDTXMania.app.Device, x + 116, y + nSenotesY, new Rectangle( 60, 240, 1, 30 ) );
                             CDTXMania.Tx.SenNotes.vc拡大縮小倍率.X = 1.0f;
                             CDTXMania.Tx.SenNotes.t2D描画(CDTXMania.app.Device, x - 2, y + nSenotesY, new Rectangle(0, 30 * pChip.nSenote, 136, 30));
                             CDTXMania.Tx.SenNotes.t2D描画(CDTXMania.app.Device, x + 56, y + nSenotesY, new Rectangle(0, 240, 60, 30));
-                            //CDTXMania.act文字コンソール.tPrint(x, y - 26, C文字コンソール.Eフォント種別.白, pChip.n発声時刻ms.ToString());
-                            //CDTXMania.act文字コンソール.tPrint( x, y - 10, C文字コンソール.Eフォント種別.白, pChip.nノーツ終了時刻ms.ToString() );
-                            //CDTXMania.act文字コンソール.tPrint( x + 60, y + 140, C文字コンソール.Eフォント種別.白, pChip.nSenote.ToString() );
                         }
                         if( pChip.nチャンネル番号 == 0x17 )
                         {


### PR DESCRIPTION
連打ノーツの大幅(?)な仕様変更
一応2つ案があるので、第一案を実行状態にし、もう一つの案をコメントアウト状態で含めている。


~~~仕様~~~

###共通###
ノーツテクスチャの先端シンボルに継続部を含めないようにする。こうしないと、先端シンボル描画部に含まれた継続部が色変化の恩恵を受けらず、見た目がおかしくなる。
継続部のRectangle範囲が128pxになっているのは、float値で拡大縮小を行うと、周囲1pzの色情報を含んで拡大を行ってしまうため、連打の一部がグラデーションしてしまう。そのためRectangle範囲を端1pxずつ狭くしている。

###末端をテクスチャ側で中央に持ってくる場合の方式###
末端シンボルを描画範囲の中央に置くことで正常に描画される方式
継続部に重ねて描画させることが可能

###末端をテクスチャ側でつなげる場合の方式###
末端シンボルを描画範囲の左端に合わせて置くことで正常に描画される方式
ノーツテクスチャの見た目でどのように描画されるかがわかりやすい
継続部にはどうやっても重ならない

どちらの方法でも、画像さえ合わせれば変わりなく描画される。
この変更によって、連打ノーツが短くても長くても、円形でも正常に描画されるようになる。


連打ノーツの色変化は、kairera0467氏の打数式を仮採用(あくまで仮)


連打ノーツ文字は、拡大率を調整。ある程度の距離があれば正常に描画される。



SimoleStyleのノーツテクスチャは、一が整っていなかったり、連打が若干ゃ斜めになっていたりするので、作り直しを推進する。