### PR TITLE
Re-wrote STYLE parsing to support vastly more valid/invalid courses for both single and double play.

### DIFF
--- a/DTXManiaプロジェクト/DTXManiaプロジェクト.csproj
+++ b/DTXManiaプロジェクト/DTXManiaプロジェクト.csproj
@@ -127,6 +127,7 @@
     <Compile Include="コード\スコア、曲\CBoxDef.cs" />
     <Compile Include="コード\スコア、曲\CCourse.cs" />
     <Compile Include="コード\スコア、曲\CDTX.cs" />
+    <Compile Include="コード\スコア、曲\CDTXStyleExtractor.cs" />
     <Compile Include="コード\スコア、曲\CScoreIni.cs" />
     <Compile Include="コード\スコア、曲\CSetDef.cs" />
     <Compile Include="コード\ステージ\01.起動\TextureLoader.cs" />

--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
@@ -2916,65 +2916,6 @@ namespace DTXMania
             return strCourseTJA;
         }
 
-        /// <summary>
-        /// セッション譜面があるかどうかを判別、あった場合は指定したプレイヤーサイドに従ったrefで切り抜いた譜面を渡す
-        /// </summary>
-        /// <param name="strTJA"></param>
-        /// <param name="strTJA2"></param>
-        /// <returns></returns>
-        private bool tセッション譜面がある( string strTJA, ref string strTJA2, int seqNo )
-        {
-            bool bIsSessionNotes = false;
-            //入力された譜面がnullでないかチェック。
-            if( string.IsNullOrEmpty( strTJA ) ) return false;
-
-            //とりあえず腑分けしてやる
-            //一旦STYLEで分ける
-            StringComparison sC = StringComparison.CurrentCultureIgnoreCase;
-            string[] str1 = strTJA.Split( new string[]{"STYLE"}, StringSplitOptions.RemoveEmptyEntries);
-            if( str1.Length < 2 ) return false;
-            //さらにDPと思われる譜面をSTARTで腑分け
-            string[] str2 = str1[ 1 ].Split( new string[]{"#START"}, StringSplitOptions.RemoveEmptyEntries );
-            //正常なDP譜面ならLength:2になる。
-            string strSingle = "";
-            string strDoubleP1 = "";
-            string strDoubleP2 = "";
-            
-
-            for( int i = 1; i < 3; i++ )
-            {
-                //腑分けした時に「#START」が消えてBGMが再生できなくなってしまうので、strDoublePnに代入する時に頭に「#START」をつけておく。
-                if( str2[ i ].IndexOf( "P1", sC ) != -1 )
-                {
-                    strDoubleP1 = ( "#START" + str2[ i ] );
-                    bIsSessionNotes = true;
-                }
-                else if( str2[ i ].IndexOf( "P2", sC ) != -1 )
-                {
-                    strDoubleP2 = ( "#START" + str2[ i ]);
-                    bIsSessionNotes = true;
-                }
-            }
-            strSingle = str1[0];
-            if ( !bIsSessionNotes ) seqNo = 99;
-
-            switch( seqNo )
-            {
-                case 0:
-                case 99:
-                    strTJA2 = strSingle;
-                    break;
-                case 1:
-                    strTJA2 = strDoubleP1;
-                    break;
-                case 2:
-                    strTJA2 = strDoubleP2;
-                    break;
-            }
-
-            return bIsSessionNotes;
-        }
-
         private static readonly Regex regexForPrefixingCommaStartingLinesWithZero = new Regex(@"^,", RegexOptions.Multiline | RegexOptions.Compiled);
         private static readonly Regex regexForStrippingHeadingLines = new Regex(
             @"^(?!(TITLE|LEVEL|BPM|WAVE|OFFSET|BALLOON|BALLOONNOR|BALLOONEXP|BALLOONMAS|SONGVOL|SEVOL|SCOREINIT|SCOREDIFF|COURSE|STYLE|GAME|LIFE|DEMOSTART|SIDE|SUBTITLE|SCOREMODE|GENRE|MOVIEOFFSET|BGIMAGE|BGMOVIE|HIDDENBRANCH|#HBSCROLL|#BMSCROLL)).+\n",
@@ -3079,7 +3020,10 @@ namespace DTXMania
                 #endregion
 
                 //指定したコースの譜面の命令を消去する。
-                this.tセッション譜面がある( strSplitした譜面[ n読み込むコース ], ref strSplitした譜面[ n読み込むコース ], CDTXMania.ConfigIni.nPlayerCount > 1 ? ( this.nPlayerSide + 1 ) : 0 );
+                strSplitした譜面[ n読み込むコース ] = CDTXStyleExtractor.tセッション譜面がある(
+                    strSplitした譜面[ n読み込むコース ],
+                    CDTXMania.ConfigIni.nPlayerCount > 1 ? ( this.nPlayerSide + 1 ) : 0,
+                    this.strファイル名の絶対パス);
 
                 //命令をすべて消去した譜面
                 var str命令消去譜面 = strSplitした譜面[ n読み込むコース ].Split( this.dlmtEnter, StringSplitOptions.RemoveEmptyEntries );

--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTXStyleExtractor.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTXStyleExtractor.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+
+namespace DTXMania
+{
+    internal static class CDTXStyleExtractor
+    {
+        private const RegexOptions CoursePlayRemovalRegexOptions =
+            RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Singleline;
+
+        private static readonly Regex CourseDoublesPlayRemovalRegex =
+            new Regex(@"^STYLE:Double$.*?^#START\sP1$.*?^#END$.*?^#START\sP2$.*?^#END$", CoursePlayRemovalRegexOptions);
+
+        private static readonly Regex CourseSinglePlayRemovalRegex =
+            new Regex(@"^STYLE:Single$.*?^#END$", CoursePlayRemovalRegexOptions);
+
+        private static readonly Regex CourseStartP1RemovalRegex =
+            new Regex(@"^#START\sP1$.*?^#END$", CoursePlayRemovalRegexOptions);
+
+        private static readonly Regex CourseStartP2RemovalRegex =
+            new Regex(@"^#START\sP2$.*?^#END$", CoursePlayRemovalRegexOptions);
+
+        /// <summary>
+        /// Determine if there is a session notation, and if there is then
+        /// return a sheet of music clipped according to the specified player Side.
+        /// </summary>
+        public static string tセッション譜面がある(string strTJA, int seqNo, string strファイル名の絶対パス)
+        {
+            void TraceError(string subMessage)
+            {
+                Trace.TraceError(FormatTraceMessage(subMessage));
+            }
+
+            void TraceWarning(string subMessage)
+            {
+                Trace.TraceWarning(FormatTraceMessage(subMessage));
+            }
+
+            string FormatTraceMessage(string subMessage)
+            {
+                return $"[i18n] {nameof(CDTXStyleExtractor)} {subMessage} (seqNo={seqNo}, {strファイル名の絶対パス})";
+            }
+
+            //入力された譜面がnullでないかチェック。
+            if (string.IsNullOrEmpty(strTJA))
+            {
+                TraceError("is returning false early due to null or empty strTJA.");
+                return strTJA;
+            }
+
+            // Having no STYLE: means there can only be a single play chart.
+            if (!strTJA.Contains("STYLE:"))
+            {
+                return strTJA;
+            }
+
+            switch (seqNo)
+            {
+                case 0:
+                    break;
+                case 1:
+                case 2:
+                {
+                    var strDouble = CourseSinglePlayRemovalRegex.Replace(strTJA, "");
+
+                    if (strDouble == strTJA)
+                    {
+                        TraceWarning("suspects incorrect STYLE:Single setup.");
+                    }
+
+                    if (!strDouble.Contains("STYLE:Double"))
+                    {
+                        TraceWarning("suspects incorrect STYLE:Double setup.");
+                    }
+
+                    var courseStartPOtherRemovalRegex = seqNo == 1 ? CourseStartP2RemovalRegex : CourseStartP1RemovalRegex;
+                    var pOther = seqNo == 1 ? 2 : 1;
+
+                    var strDoublePx = courseStartPOtherRemovalRegex.Replace(strDouble, "");
+
+                    if (strDoublePx == strDouble)
+                    {
+                        TraceWarning($"suspects incorrect STYLE:Double #START P{pOther} setup.");
+                    }
+
+                    if (strDoublePx.Contains($"#START P{seqNo}"))
+                    {
+                        return strDoublePx;
+                    }
+
+                    TraceWarning($"suspects incorrect STYLE:Double #START P{seqNo} setup. Attempting to use the single player course.");
+                    break;
+                }
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(seqNo), seqNo, "Expected 0, 1, or 2.");
+            }
+
+            var strSingle = CourseDoublesPlayRemovalRegex.Replace(strTJA, "");
+
+            if (strSingle == strTJA)
+            {
+                TraceWarning("suspects incorrect STYLE:Double setup.");
+            }
+
+            if (!strSingle.Contains("STYLE:Single"))
+            {
+                TraceWarning("suspects incorrect STYLE:Single setup.");
+            }
+
+            return strSingle;
+        }
+    }
+}


### PR DESCRIPTION
The old code used a string splitting approach. The splits easily collided with unrelated words appearing elsewhere within the tja file, causing it to be split in the wrong location(s). Such splitting also caused the parser to choose from the wrong split and either extract the wrong music sheet or extract nothing at all. The old splitting approach also caused the parser to drop relevant information which happened to appear on the wrong side of the split e.g. other course information like level, scoring, balloon information, etc.

The new code uses a string removal approach, via compiled regular expressions. This approach does not try to extract the music sheet needed for the player in question, as in the old code. Instead, this approach _removes_ the music sheet or music sheets that are _not_ needed for the player in question. This removal process is more reliable, and retains information that the old approach destroyed.

Entire patterns of errors and exceptions, unrelated to STYLE, that previously happened _elsewhere_ during parsing have now disappeared. I strongly suspect (and will be confirming in the coming days) that the old STYLE parsing code was actually causing many other parsing issues (because of its string splitting approach.)