### PR TITLE
.tja parsing safety/flexibility, logging improvements, and a few general fixes.

### DIFF
--- a/DTXManiaプロジェクト/コード/スコア、曲/CBoxDef.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CBoxDef.cs
@@ -89,7 +89,7 @@ namespace DTXMania
 					catch (Exception e)
 					{
 					    Trace.TraceError( e.ToString() );
-					    Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					    Trace.TraceError( "例外が発生しましたが処理を継続します。 (178a9a36-a59e-4264-8e4c-b3c3459db43c)" );
 						continue;
 					}
 				}

--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
@@ -1915,7 +1915,7 @@ namespace DTXMania
                     //MessageBox.Show( "おや?エラーが出たようです。お兄様。" );
                     Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                     Trace.TraceError( ex.ToString() );
-                    Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                    Trace.TraceError( "例外が発生しましたが処理を継続します。 (79ff8639-9b3c-477f-bc4a-f2eea9784860)" );
 				}
 			}
 		}
@@ -3158,7 +3158,7 @@ namespace DTXMania
                 catch( Exception ex )
                 {
                     Trace.TraceError( ex.ToString() );
-                    Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                    Trace.TraceError( "例外が発生しましたが処理を継続します。 (9e401212-0b78-4073-88d0-f7e791f36a91)" );
                 }
 
                 //if( bLog && stream != null )
@@ -3215,7 +3215,7 @@ namespace DTXMania
                 catch( Exception ex )
                 {
                     Trace.TraceError( ex.ToString() );
-                    Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                    Trace.TraceError( "例外が発生しましたが処理を継続します。 (2da1e880-6b63-4e82-b018-bf18c3568335)" );
                 }
                 //if( stream != null )
                 //{
@@ -4183,7 +4183,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (95327158-4e83-4fa9-b5e9-ad3c3d4c2a22)" );
                         break;
                     }
                     this.listBalloon_Normal.Add( n打数 );
@@ -4206,7 +4206,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (2f09063c-bfe9-40f3-90bc-61b6ddf65650)" );
                         break;
                     }
                     this.listBalloon_Normal.Add( n打数 );
@@ -4229,7 +4229,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (716b8dfd-9a54-4198-ae49-1789098ae74c)" );
                         break;
                     }
                     this.listBalloon_Expert.Add( n打数 );
@@ -4253,7 +4253,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (f27344ad-cca3-4799-9f94-2e6b36f32e8f)" );
                         break;
                     }
                     this.listBalloon_Master.Add( n打数 );
@@ -4477,7 +4477,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (34fa93e6-ed79-4ad2-bc69-8064ab9f9aa8)" );
                         break;
                     }
                     this.listBalloon_Normal.Add( n打数 );
@@ -4500,7 +4500,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (2b13e577-068e-4d09-bc09-41b004d9b804)" );
                         break;
                     }
                     this.listBalloon_Normal.Add( n打数 );
@@ -4523,7 +4523,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (6de3b837-490c-47e6-8633-ba8bef9e653e)" );
                         break;
                     }
                     this.listBalloon_Expert.Add( n打数 );
@@ -4547,7 +4547,7 @@ namespace DTXMania
                     {
                         Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (0ee8406a-38c1-40aa-b8e9-9e6df74666e0)" );
                         break;
                     }
                     this.listBalloon_Master.Add( n打数 );
@@ -4849,7 +4849,7 @@ namespace DTXMania
             catch(Exception ex)
             {
                 Trace.TraceError( ex.ToString() );
-                Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                Trace.TraceError( "例外が発生しましたが処理を継続します。 (b67473e4-1930-44f1-b320-4ead5786e74c)" );
             }
 
 
@@ -5972,7 +5972,7 @@ namespace DTXMania
                     catch( Exception ex )
                     {
                         Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (1503896a-0dfb-4643-87f1-bd821a125137)" );
                     }
                 }
                 else

--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
@@ -4335,6 +4335,7 @@ namespace DTXMania
 
 
                 strArray = strArray[ 0 ].Split( new char[] { ':' } );
+                WarnSplitLength("Header Name & Value", strArray, 2);
 
                 strCommandName = strArray[0].Trim();
                 strCommandParam = strArray[1].Trim();

--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
@@ -3007,8 +3007,13 @@ namespace DTXMania
                 strInput = regexForPrefixingCommaStartingLinesWithZero.Replace( strInput, "0," );
 
                 //2017.02.03 DD ヘッダ内にある命令以外の文字列を削除
-                string strInputHeader = strInput.Remove( strInput.IndexOf( "#START" ) );
-                strInput = strInput.Remove(0, strInput.IndexOf( "#START" ) );
+                var startIndex = strInput.IndexOf( "#START" );
+                if (startIndex < 0)
+                {
+                    Trace.TraceWarning($"[i18n] At least one #START command is required. ({strファイル名の絶対パス})");
+                }
+                string strInputHeader = strInput.Remove( startIndex );
+                strInput = strInput.Remove(0, startIndex );
                 strInputHeader = regexForStrippingHeadingLines.Replace( strInputHeader, "" );
                 strInput = strInputHeader + "\n" + strInput;
 

--- a/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CDTX.cs
@@ -4166,106 +4166,28 @@ namespace DTXMania
                 strCommandParam = strArray[1].Trim();
             }
 
-            if( strCommandName.Equals( "BALLOON" ) )
+            void ParseOptionalInt16(Action<short> setValue)
             {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
-
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (95327158-4e83-4fa9-b5e9-ad3c3d4c2a22)" );
-                        break;
-                    }
-                    this.listBalloon_Normal.Add( n打数 );
-                }
+                this.ParseOptionalInt16(strCommandName, strCommandParam, setValue);
             }
-            else if( strCommandName.Equals( "BALLOONNOR" ) )
-            {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
 
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (2f09063c-bfe9-40f3-90bc-61b6ddf65650)" );
-                        break;
-                    }
-                    this.listBalloon_Normal.Add( n打数 );
-                }
+            if( strCommandName.Equals( "BALLOON" ) || strCommandName.Equals( "BALLOONNOR" ) )
+            {
+                ParseBalloon(strCommandParam, this.listBalloon_Normal);
             }
             else if( strCommandName.Equals( "BALLOONEXP" ) )
             {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
-
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (716b8dfd-9a54-4198-ae49-1789098ae74c)" );
-                        break;
-                    }
-                    this.listBalloon_Expert.Add( n打数 );
-                }
+                ParseBalloon(strCommandParam, this.listBalloon_Expert);
                 //tbBALLOON.Text = strCommandParam;
             }
             else if( strCommandName.Equals( "BALLOONMAS" ) )
             {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
-
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (f27344ad-cca3-4799-9f94-2e6b36f32e8f)" );
-                        break;
-                    }
-                    this.listBalloon_Master.Add( n打数 );
-                }
+                ParseBalloon(strCommandParam, this.listBalloon_Master);
                 //tbBALLOON.Text = strCommandParam;
             }
             else if( strCommandName.Equals( "SCOREMODE" ) )
             {
-                if( !string.IsNullOrEmpty( strCommandParam ) )
-                {
-                    this.nScoreModeTmp = Convert.ToInt16( strCommandParam );
-                }
+                ParseOptionalInt16(value => this.nScoreModeTmp = value);
             }
             else if( strCommandName.Equals( "SCOREINIT" ) )
             {
@@ -4273,21 +4195,29 @@ namespace DTXMania
                 {
                     string[] scoreinit = strCommandParam.Split(',');
 
-                    this.nScoreInit[ 0, this.n参照中の難易度 ] = Convert.ToInt16( scoreinit[ 0 ] );
-                    this.b配点が指定されている[ 0, this.n参照中の難易度 ] = true;
-                    if( scoreinit.Length == 2 ){
-                        this.nScoreInit[ 1, this.n参照中の難易度 ] = Convert.ToInt16( scoreinit[ 1 ] );
-                        this.b配点が指定されている[ 2, this.n参照中の難易度 ] = true;
+                    this.ParseOptionalInt16("SCOREINIT first value", scoreinit[0], value =>
+                    {
+                        this.nScoreInit[0, this.n参照中の難易度] = value;
+                        this.b配点が指定されている[0, this.n参照中の難易度] = true;
+                    });
+
+                    if( scoreinit.Length == 2 )
+                    {
+                        this.ParseOptionalInt16("SCOREINIT second value", scoreinit[1], value =>
+                        {
+                            this.nScoreInit[1, this.n参照中の難易度] = value;
+                            this.b配点が指定されている[2, this.n参照中の難易度] = true;
+                        });
                     }
                 }
             }
             else if( strCommandName.Equals( "SCOREDIFF" ) )
             {
-                if( !string.IsNullOrEmpty( strCommandParam ) )
+                ParseOptionalInt16(value =>
                 {
-                    this.nScoreDiff[ this.n参照中の難易度 ] = Convert.ToInt16( strCommandParam );
-                    this.b配点が指定されている[ 1, this.n参照中の難易度 ] = true;
-                }
+                    this.nScoreDiff[this.n参照中の難易度] = value;
+                    this.b配点が指定されている[1, this.n参照中の難易度] = true;
+                });
             }
 
             if( this.nScoreModeTmp == 99 ) //2017.01.28 DD SCOREMODEを入力していない場合のみConfigで設定したモードにする
@@ -4299,7 +4229,49 @@ namespace DTXMania
             //}
         }
 
-        private void t入力_行解析ヘッダ( string InputText )
+	    private void ParseOptionalInt16(string name, string unparsedValue, Action<short> setValue)
+	    {
+	        if (string.IsNullOrEmpty(unparsedValue))
+	        {
+	            return;
+	        }
+
+	        if (short.TryParse(unparsedValue, out var value))
+	        {
+	            setValue(value);
+	        }
+	        else
+	        {
+	            Trace.TraceWarning($"[i18n] Invalid {name} value detected: {unparsedValue} ({strファイル名の絶対パス})");
+	        }
+	    }
+
+	    private void ParseBalloon(string strCommandParam, List<int> listBalloon)
+	    {
+	        string[] strParam = strCommandParam.Split(',');
+	        for (int n = 0; n < strParam.Length; n++)
+	        {
+	            int n打数;
+	            try
+	            {
+	                if (strParam[n] == null || strParam[n] == "")
+	                    break;
+
+	                n打数 = Convert.ToInt32(strParam[n]);
+	            }
+	            catch (Exception ex)
+	            {
+	                Trace.TraceError($"おや?エラーが出たようです。お兄様。 ({strファイル名の絶対パス})");
+	                Trace.TraceError(ex.ToString());
+	                Trace.TraceError("例外が発生しましたが処理を継続します。 (95327158-4e83-4fa9-b5e9-ad3c3d4c2a22)");
+	                break;
+	            }
+
+	            listBalloon.Add(n打数);
+	        }
+	    }
+
+	    private void t入力_行解析ヘッダ( string InputText )
 		{
             //やべー。先頭にコメント行あったらやばいやん。
             string[] strArray = InputText.Split( new char[] { ':' } );
@@ -4344,6 +4316,11 @@ namespace DTXMania
                 //lblMessage.Text = "おや?strArrayのLengthが2じゃないようですね。お兄様。";
             }
 
+		    void ParseOptionalInt16(Action<short> setValue)
+		    {
+		        this.ParseOptionalInt16(strCommandName, strCommandParam, setValue);
+		    }
+
             //パラメータを分別、そこから割り当てていきます。
             if (strCommandName.Equals("TITLE"))
             {
@@ -4382,20 +4359,20 @@ namespace DTXMania
             }
             else if ( strCommandName.Equals( "LEVEL" ) )
             {
-                this.LEVEL.Drums = (int)Convert.ToDouble( strCommandParam );
-                this.LEVEL.Taiko = (int)Convert.ToDouble( strCommandParam );
-                this.LEVELtaiko[ this.n参照中の難易度 ] = (int)Convert.ToDouble( strCommandParam );
+                var level = (int)Convert.ToDouble( strCommandParam );
+                this.LEVEL.Drums = level;
+                this.LEVEL.Taiko = level;
+                this.LEVELtaiko[ this.n参照中の難易度 ] = level;
             }
             else if( strCommandName.Equals( "BPM" ) )
             {
                 if( strCommandParam.IndexOf( "," ) != -1 )
                     strCommandParam = strCommandParam.Replace( ',', '.' );
 
-                this.BPM = Convert.ToDouble( strCommandParam );
-                this.BASEBPM = Convert.ToDouble( strCommandParam );
-                this.dbNowBPM = Convert.ToDouble( strCommandParam );
-
                 double dbBPM = Convert.ToDouble( strCommandParam );
+                this.BPM = dbBPM;
+                this.BASEBPM = dbBPM;
+                this.dbNowBPM = dbBPM;
 
                 this.listBPM.Add( this.n内部番号BPM1to - 1, new CBPM() { n内部番号 = this.n内部番号BPM1to - 1, n表記上の番号 = this.n内部番号BPM1to - 1, dbBPM値 = dbBPM, } );
                 this.n内部番号BPM1to++;
@@ -4460,124 +4437,47 @@ namespace DTXMania
                 //tbOFFSET.Text = strCommandParam;
             }
             #region[移動→不具合が起こるのでここも一応復活させておく]
-            else if( strCommandName.Equals( "BALLOON" ) )
+            else if( strCommandName.Equals( "BALLOON" ) || strCommandName.Equals( "BALLOONNOR" ) )
             {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
-
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (34fa93e6-ed79-4ad2-bc69-8064ab9f9aa8)" );
-                        break;
-                    }
-                    this.listBalloon_Normal.Add( n打数 );
-                }
-            }
-            else if( strCommandName.Equals( "BALLOONNOR" ) )
-            {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
-
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (2b13e577-068e-4d09-bc09-41b004d9b804)" );
-                        break;
-                    }
-                    this.listBalloon_Normal.Add( n打数 );
-                }
+                ParseBalloon(strCommandParam, this.listBalloon_Normal);
             }
             else if( strCommandName.Equals( "BALLOONEXP" ) )
             {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
-
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (6de3b837-490c-47e6-8633-ba8bef9e653e)" );
-                        break;
-                    }
-                    this.listBalloon_Expert.Add( n打数 );
-                }
+                ParseBalloon(strCommandParam, this.listBalloon_Expert);
                 //tbBALLOON.Text = strCommandParam;
             }
             else if( strCommandName.Equals( "BALLOONMAS" ) )
             {
-                string[] strParam = strCommandParam.Split( ',' );
-                for( int n = 0; n < strParam.Length; n++ )
-                {
-                    int n打数;
-                    try
-                    {
-                        if (strParam[n] == null || strParam[n] == "")
-                            break;
-
-                        n打数 = Convert.ToInt32( strParam[ n ] );
-                    }
-                    catch(Exception ex)
-                    {
-                        Trace.TraceError( "おや?エラーが出たようです。お兄様。" );
-                        Trace.TraceError( ex.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (0ee8406a-38c1-40aa-b8e9-9e6df74666e0)" );
-                        break;
-                    }
-                    this.listBalloon_Master.Add( n打数 );
-                }
+                ParseBalloon(strCommandParam, this.listBalloon_Master);
                 //tbBALLOON.Text = strCommandParam;
             }
             else if( strCommandName.Equals( "SCOREMODE" ) )
-            {
-                if( !string.IsNullOrEmpty( strCommandParam ) )
-                {
-                    this.nScoreModeTmp = Convert.ToInt16( strCommandParam );
-                }
-            }
+		    {
+		        ParseOptionalInt16(value => this.nScoreModeTmp = value);
+		    }
             else if( strCommandName.Equals( "SCOREINIT" ) )
             {
                 if( !string.IsNullOrEmpty( strCommandParam ) )
                 {
                     string[] scoreinit = strCommandParam.Split(',');
 
-                    this.nScoreInit[ 0, this.n参照中の難易度 ] = Convert.ToInt16( scoreinit[ 0 ] );
+                    this.ParseOptionalInt16("SCOREINIT first value", scoreinit[0], value =>
+                    {
+                        this.nScoreInit[0, this.n参照中の難易度] = value;
+                    });
+
                     if( scoreinit.Length == 2 )
-                        this.nScoreInit[ 1, this.n参照中の難易度 ] = Convert.ToInt16( scoreinit[ 1 ] );
+                    {
+                        this.ParseOptionalInt16("SCOREINIT second value", scoreinit[1], value =>
+                        {
+                            this.nScoreInit[1, this.n参照中の難易度] = value;
+                        });
+                    }
                 }
             }
             else if( strCommandName.Equals( "SCOREDIFF" ) )
             {
-                if( !string.IsNullOrEmpty( strCommandParam ) )
-                {
-                    this.nScoreDiff[ this.n参照中の難易度 ] = Convert.ToInt16( strCommandParam );
-                }
+                ParseOptionalInt16(value => this.nScoreDiff[this.n参照中の難易度] = value);
             }
             #endregion
             else if( strCommandName.Equals( "SONGVOL" ) && !string.IsNullOrEmpty( strCommandParam ) )

--- a/DTXManiaプロジェクト/コード/スコア、曲/CSetDef.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CSetDef.cs
@@ -215,7 +215,7 @@ namespace DTXMania
 					catch (Exception e)
 					{
 					    Trace.TraceError( e.ToString() );
-					    Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					    Trace.TraceError( "例外が発生しましたが処理を継続します。 (dbf11711-64d3-4fde-bca0-2a5e88e08de3)" );
 						continue;
 					}
 				}

--- a/DTXManiaプロジェクト/コード/スコア、曲/CSong管理.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CSong管理.cs
@@ -917,16 +917,18 @@ namespace DTXMania
 
 							#region [ 対応する .score.ini が存在していれば読み込み、Cスコア.譜面情報 に追加設定する ]
 							//-----------------
-                            //dtxのscoreiniを探す
-                            string[] dtxscoreini = Directory.GetFiles(c曲リストノード.arスコア[ i ].ファイル情報.フォルダの絶対パス, "*.dtx.score.ini");
-
                             try
                             {
-							    if( File.Exists( c曲リストノード.arスコア[ i ].ファイル情報.ファイルの絶対パス + ".score.ini" ) )
-                                    this.tScoreIniを読み込んで譜面情報を設定する( c曲リストノード.arスコア[ i ].ファイル情報.ファイルの絶対パス+ ".score.ini", ref c曲リストノード.arスコア[ i ] );
-                                else if( File.Exists( dtxscoreini[ 0 ] ) )
+                                var scoreIniPath = c曲リストノード.arスコア[ i ].ファイル情報.ファイルの絶対パス + ".score.ini";
+                                if( File.Exists( scoreIniPath ) )
+                                    this.tScoreIniを読み込んで譜面情報を設定する( scoreIniPath, c曲リストノード.arスコア[ i ] );
+                                else
                                 {
-                                    this.tScoreIniを読み込んで譜面情報を設定する( dtxscoreini[ 0 ], ref c曲リストノード.arスコア[ i ] );
+                                    string[] dtxscoreini = Directory.GetFiles(c曲リストノード.arスコア[i].ファイル情報.フォルダの絶対パス, "*.dtx.score.ini");
+                                    if (dtxscoreini.Length != 0 && File.Exists(dtxscoreini[0]))
+                                    {
+                                        this.tScoreIniを読み込んで譜面情報を設定する(dtxscoreini[0], c曲リストノード.arスコア[i]);
+                                    }
                                 }
                             }
                             catch (Exception e)
@@ -1824,7 +1826,7 @@ Debug.WriteLine( dBPM + ":" + c曲リストノード.strタイトル );
         #endregion
         #region [ .score.ini を読み込んで Cスコア.譜面情報に設定する ]
         //-----------------
-        public void tScoreIniを読み込んで譜面情報を設定する( string strScoreIniファイルパス, ref Cスコア score )
+        public void tScoreIniを読み込んで譜面情報を設定する( string strScoreIniファイルパス, Cスコア score )
 		{
 			if( !File.Exists( strScoreIniファイルパス ) )
 				return;

--- a/DTXManiaプロジェクト/コード/スコア、曲/CSong管理.cs
+++ b/DTXManiaプロジェクト/コード/スコア、曲/CSong管理.cs
@@ -720,7 +720,7 @@ namespace DTXMania
 										{
 											Trace.TraceError( "演奏記録ファイルの読み込みに失敗しました。({0})", strFileNameScoreIni );
 											Trace.TraceError( e.ToString() );
-											Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+											Trace.TraceError( "例外が発生しましたが処理を継続します。 (8ed7e0c4-4438-4e30-a8f1-6b718b150401)" );
 										}
 									}
 								}
@@ -934,7 +934,7 @@ namespace DTXMania
                             catch (Exception e)
                             {
                                 Trace.TraceError( e.ToString() );
-                                Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                                Trace.TraceError( "例外が発生しましたが処理を継続します。 (c8b6538c-46a1-403e-8cc3-fc7e7ff914fb)" );
                             }
 
 							//-----------------
@@ -1148,7 +1148,7 @@ namespace DTXMania
 			{
 				Trace.TraceError( "songs.dbの出力に失敗しました。" );
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (ca70d133-f092-4351-8ebd-0906d8f1cffa)" );
 			}
 		}
 		private void tSongsDBにノードを１つ出力する( BinaryWriter bw, C曲リストノード node )
@@ -1765,7 +1765,7 @@ Debug.WriteLine( s + ":" + c曲リストノード.strタイトル );
             catch (Exception ex)
             {
                 Trace.TraceError(ex.ToString());
-                Trace.TraceError("例外が発生しましたが処理を継続します。");
+                Trace.TraceError("例外が発生しましたが処理を継続します。 (bca6dda7-76ad-42fc-a415-250f52c0b17d)");
             }
 
         }
@@ -1884,7 +1884,7 @@ Debug.WriteLine( dBPM + ":" + c曲リストノード.strタイトル );
 			{
 				Trace.TraceError( "演奏記録ファイルの読み込みに失敗しました。[{0}]", strScoreIniファイルパス );
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (801f823d-a952-4809-a1bb-cf6a56194f5c)" );
 			}
 		}
 		//-----------------

--- a/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CActEnumSongs.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CActEnumSongs.cs
@@ -121,7 +121,7 @@ namespace DTXMania
 			{
 				Trace.TraceError( "テクスチャの生成に失敗しました。(txMessage)" );
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (761b726d-d27c-470d-be0b-a702971601b5)" );
 				this.txMessage = null;
 			}
 	

--- a/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CEnumSongs.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CEnumSongs.cs
@@ -271,7 +271,7 @@ namespace DTXMania
 								{
 									Trace.TraceWarning( "システムサウンドが存在しません。({0})", cシステムサウンド.strファイル名 );
 									Trace.TraceWarning( e.ToString() );
-									Trace.TraceWarning( "例外が発生しましたが処理を継続します。" );
+									Trace.TraceWarning( "例外が発生しましたが処理を継続します。 (3e365bf5-68e8-4425-9dcd-84ba0aafcffc)" );
 								}
 								catch ( Exception e )
 								{
@@ -359,7 +359,7 @@ namespace DTXMania
 						{
 							Trace.TraceError( "songs.db の読み込みに失敗しました。" );
 							Trace.TraceError( e.ToString() );
-							Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+							Trace.TraceError( "例外が発生しましたが処理を継続します。 (358800ac-6c52-4381-aa78-740b7383d197)" );
 						}
 
 						int scores = ( this.Songs管理 == null ) ? 0 : this.Songs管理.nSongsDBから取得できたスコア数;	// 読み込み途中でアプリ終了した場合など、CDTXMania.Songs管理 がnullの場合があるので注意
@@ -453,7 +453,7 @@ namespace DTXMania
 									catch ( Exception e )
 									{
 										Trace.TraceError( e.ToString() );
-										Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+										Trace.TraceError( "例外が発生しましたが処理を継続します。 (105fd674-e722-4a4e-bd9a-e6f82ac0b1d3)" );
 								}
 										finally
 									{
@@ -495,7 +495,7 @@ namespace DTXMania
 				catch ( Exception e )
 				{
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (76ae87e7-f737-4dfa-b8ab-5f37a06f74e8)" );
 				}
 				finally
 				{
@@ -525,7 +525,7 @@ namespace DTXMania
 				catch ( Exception e )
 				{
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (276bb40f-6406-40c1-9f03-e2a9869dbc88)" );
 				}
 				finally
 				{
@@ -552,7 +552,7 @@ namespace DTXMania
 				catch ( Exception e )
 				{
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (6480ffa0-1cc1-40d4-9cc9-aceeecd0264b)" );
 				}
 				finally
 				{
@@ -579,7 +579,7 @@ namespace DTXMania
 				catch ( Exception e )
 				{
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (a9606e11-33e6-46bc-8c79-738b3524a713)" );
 				}
 				finally
 				{
@@ -637,7 +637,7 @@ namespace DTXMania
 			{
 				bSucceededSerialize = false;
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (9ad477a4-d922-412c-b87d-e3a49a608e92)" );
 			}
 			finally
 			{
@@ -651,7 +651,7 @@ namespace DTXMania
 					catch ( Exception e )
 					{
 						Trace.TraceError( e.ToString() );
-						Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+						Trace.TraceError( "例外が発生しましたが処理を継続します。 (62860c67-b44f-46f4-b4fc-999c6fe18cce)" );
 					}
 				}
 			}
@@ -687,7 +687,7 @@ namespace DTXMania
 						// songs管理 = null;
 
 						Trace.TraceError( e.ToString() );
-						Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+						Trace.TraceError( "例外が発生しましたが処理を継続します。 (a4289e34-7140-4b67-b821-3b5370a725e1)" );
 					}
 				}
 				#endregion
@@ -696,7 +696,7 @@ namespace DTXMania
 			{
 				Trace.TraceError( "songlist.db の読み込みに失敗しました。" );
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (5a907ed2-f849-4bc4-acd0-d2a6aa3c9c87)" );
 			}
 			return null;
 		}

--- a/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CEnumSongs.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CEnumSongs.cs
@@ -267,11 +267,9 @@ namespace DTXMania
 									//	cシステムサウンド.t再生する();
 									//}
 								}
-								catch ( FileNotFoundException e )
+								catch ( FileNotFoundException )
 								{
 									Trace.TraceWarning( "システムサウンドが存在しません。({0})", cシステムサウンド.strファイル名 );
-									Trace.TraceWarning( e.ToString() );
-									Trace.TraceWarning( "例外が発生しましたが処理を継続します。 (3e365bf5-68e8-4425-9dcd-84ba0aafcffc)" );
 								}
 								catch ( Exception e )
 								{

--- a/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CEnumSongs.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/02.タイトル/CEnumSongs.cs
@@ -664,10 +664,15 @@ namespace DTXMania
 		/// <param name="strPathSongList"></param>
 		private CSongs管理 Deserialize( string strPathSongList )
 		{
-			CSongs管理 songs管理 = null;
 			try
 			{
 				#region [ SongListDB(songlist.db)を読み込む ]
+
+			    if (!File.Exists(strPathSongList))
+			    {
+			        return null;
+			    }
+
 				//	byte[] buf = File.ReadAllBytes( SongListDBファイル名 );			// 一旦メモリにまとめ読みしてからdeserializeした方が高速かと思ったら全く変わらなかったので削除
 				//	using ( MemoryStream input = new MemoryStream(buf, false) )
 				using ( Stream input = File.OpenRead( strPathSongList ) )
@@ -675,7 +680,7 @@ namespace DTXMania
 					try
 					{
 						BinaryFormatter formatter = new BinaryFormatter();
-						songs管理 = (CSongs管理) formatter.Deserialize( input );
+						return (CSongs管理) formatter.Deserialize( input );
 					}
 					catch ( Exception e )
 					{
@@ -693,7 +698,7 @@ namespace DTXMania
 				Trace.TraceError( e.ToString() );
 				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
 			}
-			return songs管理;
+			return null;
 		}
 	}
 }

--- a/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CActConfigList.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CActConfigList.cs
@@ -1800,11 +1800,12 @@ namespace DTXMania
 				}
 				else
 				{
-					Bitmap bmpItem = prvFont.DrawPrivateFont( this.list項目リスト[ nItem ].str項目名, Color.White, Color.Black );
-					listMenu[ nItem ].txMenuItemRight = CDTXMania.tテクスチャの生成( bmpItem );
-					//					ctItem.t2D描画( CDTXMania.app.Device, ( x + 0x12 ) * Scale.X, ( y + 12 ) * Scale.Y - 20 );
-					//					CDTXMania.tテクスチャの解放( ref ctItem );
-					CDTXMania.t安全にDisposeする( ref bmpItem );
+					using (var bmpItem = prvFont.DrawPrivateFont( this.list項目リスト[ nItem ].str項目名, Color.White, Color.Black ))
+					{
+					    listMenu[ nItem ].txMenuItemRight = CDTXMania.tテクスチャの生成( bmpItem );
+					    // ctItem.t2D描画( CDTXMania.app.Device, ( x + 0x12 ) * Scale.X, ( y + 12 ) * Scale.Y - 20 );
+					    // CDTXMania.tテクスチャの解放( ref ctItem );
+					}
 				}
 				//CDTXMania.stageコンフィグ.actFont.t文字列描画( x + 0x12, y + 12, this.list項目リスト[ nItem ].str項目名 );
 				//-----------------
@@ -1896,13 +1897,13 @@ namespace DTXMania
 				}
 				if ( b強調 )
 				{
-					Bitmap bmpStr = b強調 ?
-						prvFont.DrawPrivateFont( strParam, Color.Black, Color.White, Color.Yellow, Color.OrangeRed ) :
-						prvFont.DrawPrivateFont( strParam, Color.Black, Color.White );
-					CTexture txStr = CDTXMania.tテクスチャの生成( bmpStr, false );
-					txStr.t2D描画( CDTXMania.app.Device, x + 400, y + 12 );
-					CDTXMania.tテクスチャの解放( ref txStr );
-					CDTXMania.t安全にDisposeする( ref bmpStr );
+				    using (var bmpStr = prvFont.DrawPrivateFont(strParam, Color.Black, Color.White, Color.Yellow, Color.OrangeRed))
+				    {
+				        using (var txStr = CDTXMania.tテクスチャの生成( bmpStr, false ))
+				        {
+				            txStr.t2D描画( CDTXMania.app.Device, x + 400, y + 12 );
+				        }
+				    }
 				}
 				else
 				{
@@ -1914,10 +1915,10 @@ namespace DTXMania
 						object o = this.list項目リスト[ nItem ].obj現在値();
 						stm.strParam = ( o == null ) ? "" : o.ToString();
 
-						Bitmap bmpStr =
-							prvFont.DrawPrivateFont( strParam, Color.White, Color.Black );
-						stm.txParam = CDTXMania.tテクスチャの生成( bmpStr, false );
-						CDTXMania.t安全にDisposeする( ref bmpStr );
+						using (var bmpStr = prvFont.DrawPrivateFont( strParam, Color.White, Color.Black ))
+						{
+						    stm.txParam = CDTXMania.tテクスチャの生成( bmpStr, false );
+						}
 
 						listMenu[ nItem ] = stm;
 					}

--- a/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CStageコンフィグ.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CStageコンフィグ.cs
@@ -96,12 +96,12 @@ namespace DTXMania
 			{
 			    Trace.TraceError( e.ToString() );
 				Trace.TraceError( "ファイルが読み取り専用になっていないか、管理者権限がないと書き込めなくなっていないか等を確認して下さい" );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (7a61f01b-1703-4aad-8d7d-08bd88ae8760)" );
 			}
 			catch ( Exception e )
 			{
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (83f0d93c-bb04-4a19-a596-bc32de39f496)" );
 			}
 			finally
 			{

--- a/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CStageコンフィグ.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CStageコンフィグ.cs
@@ -117,20 +117,24 @@ namespace DTXMania
 				//this.tx上部パネル = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\4_header panel.png" ) );
 				//this.tx下部パネル = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\4_footer panel.png" ) );
 				//this.txMenuカーソル = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\ScreenConfig menu cursor.png" ) );
-				prvFont = new CPrivateFastFont( CSkin.Path( @"mplus-1p-heavy.ttf" ), 20 );
-				string[] strMenuItem = { "System", "Drums", "Exit" };
-				txMenuItemLeft = new CTexture[ strMenuItem.Length, 2 ];
-				for ( int i = 0; i < strMenuItem.Length; i++ )
-				{
-					Bitmap bmpStr;
-					bmpStr = prvFont.DrawPrivateFont( strMenuItem[ i ], Color.White, Color.Black );
-					txMenuItemLeft[ i, 0 ] = CDTXMania.tテクスチャの生成( bmpStr, false );
-					bmpStr.Dispose();
-					bmpStr = prvFont.DrawPrivateFont( strMenuItem[ i ], Color.White, Color.Black, Color.Yellow, Color.OrangeRed );
-					txMenuItemLeft[ i, 1 ] = CDTXMania.tテクスチャの生成( bmpStr, false );
-					bmpStr.Dispose();
-				}
-				if( this.bメニューにフォーカス中 )
+			    string[] strMenuItem = {"System", "Drums", "Exit"};
+			    txMenuItemLeft = new CTexture[strMenuItem.Length, 2];
+			    using (var prvFont = new CPrivateFastFont(CSkin.Path(@"mplus-1p-heavy.ttf"), 20))
+			    {
+			        for (int i = 0; i < strMenuItem.Length; i++)
+			        {
+			            using (var bmpStr = prvFont.DrawPrivateFont(strMenuItem[i], Color.White, Color.Black))
+			            {
+			                txMenuItemLeft[i, 0] = CDTXMania.tテクスチャの生成(bmpStr, false);
+			            }
+			            using (var bmpStr = prvFont.DrawPrivateFont(strMenuItem[i], Color.White, Color.Black, Color.Yellow, Color.OrangeRed))
+			            {
+			                txMenuItemLeft[i, 1] = CDTXMania.tテクスチャの生成(bmpStr, false);
+			            }
+			        }
+			    }
+
+			    if( this.bメニューにフォーカス中 )
 				{
 					this.t説明文パネルに現在選択されているメニューの説明を描画する();
 				}
@@ -150,7 +154,6 @@ namespace DTXMania
 				//CDTXMania.tテクスチャの解放( ref this.tx下部パネル );
 				//CDTXMania.tテクスチャの解放( ref this.txMenuカーソル );
 				CDTXMania.tテクスチャの解放( ref this.tx説明文パネル );
-				prvFont.Dispose();
 				for ( int i = 0; i < txMenuItemLeft.GetLength( 0 ); i++ )
 				{
 					txMenuItemLeft[ i, 0 ].Dispose();
@@ -453,7 +456,6 @@ namespace DTXMania
 		//private CTexture tx上部パネル;
 		private CTexture tx説明文パネル;
 		//private CTexture tx背景;
-        private CPrivateFastFont prvFont;
 		private CTexture[ , ] txMenuItemLeft;
 
 		private void tカーソルを下へ移動する()

--- a/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectPopupMenu.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectPopupMenu.cs
@@ -65,15 +65,21 @@ namespace DTXMania
 			stqMenuTitle = new stQuickMenuItem();
 			stqMenuTitle.cItem = new CItemBase();
 			stqMenuTitle.cItem.str項目名 = title;
-			stqMenuTitle.txName = CDTXMania.tテクスチャの生成( prvFont.DrawPrivateFont( title, Color.White, Color.Black ), false );
-			stqMenuTitle.rectName = prvFont.RectStrings;
+		    using (var bitmap = prvFont.DrawPrivateFont( title, Color.White, Color.Black ))
+		    {
+		        stqMenuTitle.txName = CDTXMania.tテクスチャの生成( bitmap, false );
+		        stqMenuTitle.rectName = prvFont.RectStrings;
+		    }
 			lciMenuItems = new stQuickMenuItem[ menulist.Count ];
 			for (int i = 0; i < menulist.Count; i++ )
 			{
 				stQuickMenuItem stqm = new stQuickMenuItem();
 				stqm.cItem = menulist[ i ];
-				stqm.txName = CDTXMania.tテクスチャの生成( prvFont.DrawPrivateFont( menulist[ i ].str項目名, Color.White, Color.Black ), false );
-				stqm.rectName = prvFont.RectStrings;
+			    using (var bitmap = prvFont.DrawPrivateFont( menulist[ i ].str項目名, Color.White, Color.Black ))
+			    {
+			        stqm.txName = CDTXMania.tテクスチャの生成( bitmap, false );
+			        stqm.rectName = prvFont.RectStrings;
+			    }
 				lciMenuItems[ i ] = stqm;
 			}
 
@@ -375,12 +381,15 @@ namespace DTXMania
                                 break;
                         }
                         //font.t文字列描画( (int)(340 * Scale.X), (int)(80 + i * 32), s, bValueBold, 1.0f * Scale.Y);
-                        Bitmap bmpStr = bValueBold ?
+                        using (var bmpStr = bValueBold ?
                             prvFont.DrawPrivateFont(s, Color.White, Color.Black, Color.Yellow, Color.OrangeRed) :
-                            prvFont.DrawPrivateFont(s, Color.White, Color.Black);
-                        CTexture ctStr = CDTXMania.tテクスチャの生成(bmpStr, false);
-                        ctStr.t2D描画(CDTXMania.app.Device, 330, 77 + i * 32);
-                        CDTXMania.tテクスチャの解放(ref ctStr);
+                            prvFont.DrawPrivateFont(s, Color.White, Color.Black))
+                        {
+                            using (var ctStr = CDTXMania.tテクスチャの生成(bmpStr, false))
+                            {
+                                ctStr.t2D描画(CDTXMania.app.Device, 330, 77 + i * 32);
+                            }
+                        }
                     }
 				}
 				#endregion

--- a/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectPreimageパネル.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelectPreimageパネル.cs
@@ -553,7 +553,7 @@ namespace DTXMania
 						{
 							Trace.TraceError( "codecがないと、D3DERR_INVALIDCALLが発生する場合がある" );
 							Trace.TraceError( e.ToString() );
-							Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+							Trace.TraceError( "例外が発生しましたが処理を継続します。 (ba21ae56-afaa-47b9-a5c7-1a6bb21085eb)" );
 						}
 						return;
 					}

--- a/DTXManiaプロジェクト/コード/ステージ/06.曲読み込み/CStage曲読み込み.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/06.曲読み込み/CStage曲読み込み.cs
@@ -102,18 +102,16 @@ namespace DTXMania
                         //this.txタイトル = new CTexture( CDTXMania.app.Device, image, CDTXMania.TextureFormat );
                         //this.txタイトル.vc拡大縮小倍率 = new Vector3( 0.5f, 0.5f, 1f );
 
-                        Bitmap bmpSongTitle = new Bitmap(1, 1);
-                        bmpSongTitle = this.pfTITLE.DrawPrivateFont( this.str曲タイトル, Color.White, Color.Black );
-						this.txタイトル = new CTexture( CDTXMania.app.Device, bmpSongTitle, CDTXMania.TextureFormat, false );
-                        txタイトル.vc拡大縮小倍率.X = CDTXMania.GetSongNameXScaling(ref txタイトル, 710);
-                        Bitmap bmpSongSubTitle = new Bitmap(1, 1);
-                        bmpSongSubTitle = this.pfSUBTITLE.DrawPrivateFont( this.strサブタイトル, Color.White, Color.Black );
-						this.txサブタイトル = new CTexture( CDTXMania.app.Device, bmpSongSubTitle, CDTXMania.TextureFormat, false );
+					    using (var bmpSongTitle = this.pfTITLE.DrawPrivateFont( this.str曲タイトル, Color.White, Color.Black ))
+					    {
+					        this.txタイトル = new CTexture( CDTXMania.app.Device, bmpSongTitle, CDTXMania.TextureFormat, false );
+					        txタイトル.vc拡大縮小倍率.X = CDTXMania.GetSongNameXScaling(ref txタイトル, 710);
+					    }
 
-                        //image.Dispose();
-                        CDTXMania.t安全にDisposeする( ref bmpSongTitle );
-                        CDTXMania.t安全にDisposeする( ref bmpSongSubTitle );
-                        
+					    using (var bmpSongSubTitle = this.pfSUBTITLE.DrawPrivateFont( this.strサブタイトル, Color.White, Color.Black ))
+					    {
+					        this.txサブタイトル = new CTexture( CDTXMania.app.Device, bmpSongSubTitle, CDTXMania.TextureFormat, false );
+					    }
                     }
 					else
 					{

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CAct演奏パネル文字列.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CAct演奏パネル文字列.cs
@@ -33,12 +33,12 @@ namespace DTXMania
 				{
 					try
 					{
-                        Bitmap bmpSongTitle = new Bitmap(1, 1);
-                        bmpSongTitle = pfMusicName.DrawPrivateFont( this.strパネル文字列, Color.White, Color.Black );
-                        //Bitmap bmpVTest = new Bitmap( 1, 1 );
-                        //bmpVTest = pf縦書きテスト.DrawPrivateFont( this.strパネル文字列, Color.White, Color.Black, true );
-                        this.txMusicName = CDTXMania.tテクスチャの生成( bmpSongTitle, false );
-                        Bitmap bmpDiff = new Bitmap(1, 1);
+					    using (var bmpSongTitle = pfMusicName.DrawPrivateFont( this.strパネル文字列, Color.White, Color.Black ))
+					    {
+					        this.txMusicName = CDTXMania.tテクスチャの生成( bmpSongTitle, false );
+					    }
+
+                        Bitmap bmpDiff;
                         string strDiff = "";
                         if (CDTXMania.Skin.eDiffDispMode == E難易度表示タイプ.n曲目に表示)
                         {
@@ -75,10 +75,11 @@ namespace DTXMania
                                 bmpDiff = pfMusicName.DrawPrivateFont(CDTXMania.Skin.Game_StageText, Color.White, Color.Black);
                             }
                         }
-                        this.tx難易度とステージ数 = CDTXMania.tテクスチャの生成( bmpDiff, false );
 
-                        CDTXMania.t安全にDisposeする( ref bmpDiff );
-                        CDTXMania.t安全にDisposeする( ref bmpSongTitle );
+					    using (bmpDiff)
+					    {
+					        this.tx難易度とステージ数 = CDTXMania.tテクスチャの生成( bmpDiff, false );
+					    }
 					}
 					catch( CTextureCreateFailedException e )
 					{
@@ -124,8 +125,10 @@ namespace DTXMania
                     }
                     else
                     {
-                        Bitmap bmpDummy = new Bitmap( 1, 1 );
-                        this.txGENRE = CDTXMania.tテクスチャの生成( bmpDummy, true );
+                        using (var bmpDummy = new Bitmap( 1, 1 ))
+                        {
+                            this.txGENRE = CDTXMania.tテクスチャの生成( bmpDummy, true );
+                        }
                     }
                 }
 
@@ -139,10 +142,10 @@ namespace DTXMania
 
         public void t歌詞テクスチャを生成する( string str歌詞 )
         {
-            Bitmap bmpleric = new Bitmap(1, 1);
-            bmpleric = this.pf歌詞フォント.DrawPrivateFont( str歌詞, Color.White, Color.Blue);
-            this.tx歌詞テクスチャ = CDTXMania.tテクスチャの生成( bmpleric, false );
-            CDTXMania.t安全にDisposeする( ref bmpleric );
+            using (var bmpleric = this.pf歌詞フォント.DrawPrivateFont( str歌詞, Color.White, Color.Blue))
+            {
+                this.tx歌詞テクスチャ = CDTXMania.tテクスチャの生成( bmpleric, false );
+            }
         }
 
         /// <summary>

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
@@ -4439,7 +4439,7 @@ namespace DTXMania
             catch (Exception e)
             {
                 Trace.TraceError( e.ToString() );
-                Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                Trace.TraceError( "例外が発生しましたが処理を継続します。 (a80767e1-4de7-4fec-b072-d078b3659e62)" );
                 this.tx背景 = null;
             }
 		}

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
@@ -192,7 +192,7 @@ namespace DTXMania
 			if( CDTXMania.bコンパクトモード )
 			{
 				var score = new Cスコア();
-				CDTXMania.Songs管理.tScoreIniを読み込んで譜面情報を設定する( CDTXMania.strコンパクトモードファイル + ".score.ini", ref score );
+				CDTXMania.Songs管理.tScoreIniを読み込んで譜面情報を設定する( CDTXMania.strコンパクトモードファイル + ".score.ini", score );
 			}
 			else
 			{

--- a/DTXManiaプロジェクト/コード/ステージ/08.結果/CActResultSongBar.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/08.結果/CActResultSongBar.cs
@@ -42,16 +42,16 @@ namespace DTXMania
             }
 
 
-            Bitmap bmpSongTitle = new Bitmap(1, 1);
-            Bitmap bmpStageText = new Bitmap(1, 1);
-            bmpSongTitle = pfMusicName.DrawPrivateFont( CDTXMania.DTX.TITLE, Color.White, Color.Black );
+		    using (var bmpSongTitle = pfMusicName.DrawPrivateFont(CDTXMania.DTX.TITLE, Color.White, Color.Black))
+		    {
+		        this.txMusicName = CDTXMania.tテクスチャの生成(bmpSongTitle, false);
+		        txMusicName.vc拡大縮小倍率.X = CDTXMania.GetSongNameXScaling(ref txMusicName);
+		    }
 
-            bmpStageText = pfStageText.DrawPrivateFont(CDTXMania.Skin.Game_StageText, Color.White, Color.Black);
-            this.txStageText = CDTXMania.tテクスチャの生成(bmpStageText, false);
-            
-
-            this.txMusicName = CDTXMania.tテクスチャの生成( bmpSongTitle, false );
-            txMusicName.vc拡大縮小倍率.X = CDTXMania.GetSongNameXScaling(ref txMusicName);
+		    using (var bmpStageText = pfStageText.DrawPrivateFont(CDTXMania.Skin.Game_StageText, Color.White, Color.Black))
+		    {
+		        this.txStageText = CDTXMania.tテクスチャの生成(bmpStageText, false);
+		    }
 
 			base.On活性化();
 		}

--- a/DTXManiaプロジェクト/コード/ステージ/CDTXVmode.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/CDTXVmode.cs
@@ -363,7 +363,7 @@ namespace DTXMania
 						catch (Exception e)	// 指定ファイルが存在しない
 						{
 							Trace.TraceError( e.ToString() );
-							Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+							Trace.TraceError( "例外が発生しましたが処理を継続します。 (d309a608-7311-411e-a565-19226c3116c2)" );
 						}
 						arg = "";
 						analyzing = false;
@@ -395,7 +395,7 @@ Trace.TraceInformation( "Command: " + s[ (int) this.Command ] );
 					{
 						//ConfigIni = new CConfigIni();	// 存在してなければ新規生成
 						Trace.TraceError( e.ToString() );
-						Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+						Trace.TraceError( "例外が発生しましたが処理を継続します。 (825f9ba6-9164-4f2e-8c41-edf4d73c06c9)" );
 					}
 				}
 				fi = null;

--- a/DTXManiaプロジェクト/コード/全体/CActFlushGPU.cs
+++ b/DTXManiaプロジェクト/コード/全体/CActFlushGPU.cs
@@ -28,7 +28,7 @@ namespace DTXMania
 				catch ( Exception e )
 				{
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (e5c7cd0b-f7bb-4bf1-9ad9-db27b43ff63d)" );
 				}
 				base.OnManagedリソースの作成();
 			}

--- a/DTXManiaプロジェクト/コード/全体/CConfigIni.cs
+++ b/DTXManiaプロジェクト/コード/全体/CConfigIni.cs
@@ -2802,7 +2802,7 @@ namespace DTXMania
 					catch ( Exception exception )
 					{
 						Trace.TraceError( exception.ToString() );
-						Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+						Trace.TraceError( "例外が発生しましたが処理を継続します。 (93c4c5cd-4996-4e8c-a82f-a179ff590b44)" );
 						continue;
 					}
 				}

--- a/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
+++ b/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
@@ -1594,10 +1594,9 @@ for (int i = 0; i < 3; i++) {
 				Trace.TraceError( "テクスチャの生成に失敗しました。({0})", fileName );
 				return null;
 			}
-			catch ( FileNotFoundException e )
+			catch ( FileNotFoundException )
 			{
-				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "テクスチャファイルが見つかりませんでした。({0})", fileName );
+				Trace.TraceWarning( "テクスチャファイルが見つかりませんでした。({0})", fileName );
 				return null;
 			}
 		}

--- a/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
+++ b/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
@@ -426,7 +426,7 @@ namespace DTXMania
 				catch (Exception e)
 				{
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (0bfe6bff-2a56-4df4-9333-2df26d9b765b)" );
 					return false;
 				}
 			}
@@ -1814,7 +1814,7 @@ for (int i = 0; i < 3; i++) {
 				{
 					//ConfigIni = new CConfigIni();	// 存在してなければ新規生成
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (b8d93255-bbe4-4ca3-8264-7ee5175b19f3)" );
 				}
 			}
 			this.Window.EnableSystemMenu = CDTXMania.ConfigIni.bIsEnabledSystemMenu;	// #28200 2011.5.1 yyagi

--- a/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
+++ b/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
@@ -84,9 +84,8 @@ namespace DTXMania
 					this._pfc.AddFontFile(fontpath);								//PrivateFontCollectionにフォントを追加する
 					_fontfamily = _pfc.Families[0];
 				}
-				catch (System.IO.FileNotFoundException e)
+				catch (System.IO.FileNotFoundException)
 				{
-					Trace.TraceWarning( e.ToString() );
 					Trace.TraceWarning("プライベートフォントの追加に失敗しました({0})。代わりにMS UI Gothicの使用を試みます。", fontpath);
 					//throw new FileNotFoundException( "プライベートフォントの追加に失敗しました。({0})", Path.GetFileName( fontpath ) );
 					//return;

--- a/DTXManiaプロジェクト/コード/全体/CSkin.cs
+++ b/DTXManiaプロジェクト/コード/全体/CSkin.cs
@@ -225,7 +225,7 @@ namespace DTXMania
 					catch (Exception e)
 					{
 						Trace.TraceError( e.ToString() );
-						Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+						Trace.TraceError( "例外が発生しましたが処理を継続します。 (17668977-4686-4aa7-b3f0-e0b9a44975b8)" );
 						this.b読み込み未試行 = false;
 					}
 				}
@@ -1741,7 +1741,7 @@ namespace DTXMania
                     catch( Exception exception )
                     {
                         Trace.TraceError( exception.ToString() );
-                        Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                        Trace.TraceError( "例外が発生しましたが処理を継続します。 (6a32cc37-1527-412e-968a-512c1f0135cd)" );
                         continue;
                     }
                 }

--- a/DTXManiaプロジェクト/コード/全体/CSkin.cs
+++ b/DTXManiaプロジェクト/コード/全体/CSkin.cs
@@ -868,6 +868,19 @@ namespace DTXMania
                             strParam = strArray[1].Trim();
 
                             #region スキン設定
+
+                            void ParseInt32(Action<int> setValue)
+                            {
+                                if (int.TryParse(strParam, out var unparsedValue))
+                                {
+                                    setValue(unparsedValue);
+                                }
+                                else
+                                {
+                                    Trace.TraceWarning($"[i18n] {strCommand} must be an integer value. The provided value is invalid: {strParam}");
+                                }
+                            }
+
                             if (strCommand == "Name")
                             {
                                 this.Skin_Name = strParam;
@@ -1153,15 +1166,15 @@ namespace DTXMania
                             }
                             else if (strCommand == "Game_Chara_Beat_Normal")
                             {
-                                Game_Chara_Beat_Normal = int.Parse(strParam);
+                                ParseInt32(value => Game_Chara_Beat_Normal = value);
                             }
                             else if (strCommand == "Game_Chara_Beat_Clear")
                             {
-                                Game_Chara_Beat_Clear = int.Parse(strParam);
+                                ParseInt32(value => Game_Chara_Beat_Clear = value);
                             }
                             else if (strCommand == "Game_Chara_Beat_GoGo")
                             {
-                                Game_Chara_Beat_GoGo = int.Parse(strParam);
+                                ParseInt32(value => Game_Chara_Beat_GoGo = value);
                             }
                             #endregion
                             #region Dancer
@@ -1188,7 +1201,7 @@ namespace DTXMania
                             // Game_Dancer_PtnはTextrueLoader.csで反映されます。
                             else if (strCommand == "Game_Dancer_Beat")
                             {
-                                Game_Dancer_Beat = int.Parse(strParam);
+                                ParseInt32(value => Game_Dancer_Beat = value);
                             }
                             else if (strCommand == "Game_Dancer_Gauge")
                             {
@@ -1202,11 +1215,11 @@ namespace DTXMania
                             #region Mob
                             else if (strCommand == "Game_Mob_Beat")
                             {
-                                Game_Mob_Beat = int.Parse(strParam);
+                                ParseInt32(value => Game_Mob_Beat = value);
                             }
                             else if (strCommand == "Game_Mob_Ptn_Beat")
                             {
-                                Game_Mob_Ptn_Beat = int.Parse(strParam);
+                                ParseInt32(value => Game_Mob_Ptn_Beat = value);
                             }
                             #endregion
                             #region Score
@@ -1261,8 +1274,7 @@ namespace DTXMania
 
                             else if (strCommand == "Game_Score_Padding")
                             {
-                                Game_Score_Padding = int.Parse(strParam);
-
+                                ParseInt32(value => Game_Score_Padding = value);
                             }
                             else if (strCommand == "Game_Score_Size")
                             {
@@ -1613,15 +1625,15 @@ namespace DTXMania
                             }
                             else if (strCommand == "Game_Balloon_Number_Padding")
                             {
-                                Game_Balloon_Number_Padding = int.Parse(strParam);
+                                ParseInt32(value => Game_Balloon_Number_Padding = value);
                             }
                             else if (strCommand == "Game_Balloon_Roll_Number_Scale")
                             {
-                                Game_Balloon_Roll_Number_Scale = float.Parse(strParam);
+                                ParseInt32(value => Game_Balloon_Roll_Number_Scale = value);
                             }
                             else if (strCommand == "Game_Balloon_Balloon_Number_Scale")
                             {
-                                Game_Balloon_Balloon_Number_Scale = float.Parse(strParam);
+                                ParseInt32(value => Game_Balloon_Balloon_Number_Scale = value);
                             }
 
                             #endregion
@@ -1686,11 +1698,11 @@ namespace DTXMania
                             }
                             else if (strCommand == "Game_Runner_Ptn")
                             {
-                                Game_Runner_Ptn = int.Parse(strParam);
+                                ParseInt32(value => Game_Runner_Ptn = value);
                             }
                             else if (strCommand == "Game_Runner_Type")
                             {
-                                Game_Runner_Type = int.Parse(strParam);
+                                ParseInt32(value => Game_Runner_Type = value);
                             }
                             else if (strCommand == "Game_Runner_StartPoint_X")
                             {

--- a/DTXManiaプロジェクト/コード/全体/CSkin.cs
+++ b/DTXManiaプロジェクト/コード/全体/CSkin.cs
@@ -175,7 +175,8 @@ namespace DTXMania
 
 				if( !File.Exists( CSkin.Path( this.strファイル名 ) ) )
 				{
-					throw new FileNotFoundException( this.strファイル名 );
+                    Trace.TraceWarning($"[i18n] File does not exist: {this.strファイル名}");
+				    return;
 				}
 ////				for( int i = 0; i < 2; i++ )		// #27790 2012.3.10 yyagi 2回読み出しを、1回読みだし＋1回メモリコピーに変更
 ////				{

--- a/FDK17プロジェクト/コード/01.フレームワーク/Core/GameWindow.cs
+++ b/FDK17プロジェクト/コード/01.フレームワーク/Core/GameWindow.cs
@@ -562,12 +562,12 @@ namespace SampleFramework
             catch (ArgumentNullException e)
             {
                 Trace.TraceError( e.ToString() );
-                Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                Trace.TraceError( "例外が発生しましたが処理を継続します。 (6216f3e1-e1a5-45ca-bfd8-30bbc44bfa9a)" );
             }
             catch (UriFormatException e)
             {
                 Trace.TraceError( e.ToString() );
-                Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+                Trace.TraceError( "例外が発生しましたが処理を継続します。 (771f37b5-0b56-4a47-933e-3c178b3e27a7)" );
             }
 
             return DefaultTitle;

--- a/FDK17プロジェクト/コード/01.フレームワーク/Rendering/GraphicsDeviceManager.cs
+++ b/FDK17プロジェクト/コード/01.フレームワーク/Rendering/GraphicsDeviceManager.cs
@@ -579,7 +579,7 @@ namespace SampleFramework
 			{
 				// 時々発生するのでキャッチしておく。
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (fc0b6e70-181e-410f-b47f-5490ca4ce0c3)" );
 			}
             Direct3D9Object.Dispose();
 

--- a/FDK17プロジェクト/コード/02.入力/CInputJoystick.cs
+++ b/FDK17プロジェクト/コード/02.入力/CInputJoystick.cs
@@ -49,7 +49,7 @@ namespace FDK
 			catch( DirectInputException e )
 			{
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (5658360e-2745-4c5c-ab2d-ff82287d3e8a)" );
 			}
 
 			for( int i = 0; i < this.bButtonState.Length; i++ )

--- a/FDK17プロジェクト/コード/02.入力/CInputKeyboard.cs
+++ b/FDK17プロジェクト/コード/02.入力/CInputKeyboard.cs
@@ -40,7 +40,7 @@ namespace FDK
 			catch( DirectInputException e)
 			{
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (21a6c966-e27d-48f6-ac89-125ea4bc1a06)" );
 			}
 
 			for( int i = 0; i < this.bKeyState.Length; i++ )

--- a/FDK17プロジェクト/コード/02.入力/CInputMouse.cs
+++ b/FDK17プロジェクト/コード/02.入力/CInputMouse.cs
@@ -45,7 +45,7 @@ namespace FDK
 			catch( DirectInputException e )
 			{
 				Trace.TraceError( e.ToString() );
-				Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+				Trace.TraceError( "例外が発生しましたが処理を継続します。 (803ffb80-d2ca-425f-8f95-05d7c7cc8d90)" );
 			}
 
 			for( int i = 0; i < this.bMouseState.Length; i++ )

--- a/FDK17プロジェクト/コード/03.サウンド/CSound.cs
+++ b/FDK17プロジェクト/コード/03.サウンド/CSound.cs
@@ -365,6 +365,7 @@ namespace FDK
 		{
             if( !File.Exists( filename ) )
             {
+                Trace.TraceWarning($"[i18n] File does not exist: {filename}");
                 return null;
             }
 

--- a/FDK17プロジェクト/コード/03.サウンド/CSound.cs
+++ b/FDK17プロジェクト/コード/03.サウンド/CSound.cs
@@ -272,7 +272,7 @@ namespace FDK
 				catch ( Exception e )
 				{
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (2609806d-23e8-45c2-9389-b427e80915bc)" );
 					if ( ESoundDeviceTypes[ n初期デバイス ] == ESoundDeviceType.Unknown )
 					{
 						Trace.TraceError( string.Format( "サウンドデバイスの初期化に失敗しました。" ) );
@@ -1340,7 +1340,7 @@ Debug.WriteLine("更に再生に失敗: " + Path.GetFileName(this.strファイ�
 				{
 					Trace.TraceError( "{0}: Seek error: {1}", Path.GetFileName( this.strファイル名 ), n位置ms);
 					Trace.TraceError( e.ToString() );
-					Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+					Trace.TraceError( "例外が発生しましたが処理を継続します。 (95dee242-1f92-4fcf-aaf6-b162ad2bfc03)" );
 				}
 				//if ( this.n総演奏時間ms > 5000 )
 				//{
@@ -1480,7 +1480,7 @@ Debug.WriteLine("更に再生に失敗: " + Path.GetFileName(this.strファイ�
 						{
 							// 演奏終了後、長時間解放しないでいると、たまに AccessViolationException が発生することがある。
 							Trace.TraceError( e.ToString() );
-							Trace.TraceError( "例外が発生しましたが処理を継続します。" );
+							Trace.TraceError( "例外が発生しましたが処理を継続します。 (19bcaa24-5259-4198-bf74-41eb1114ba28)" );
 						}
 						C共通.tDisposeする( ref this.Buffer );
 					}

--- a/FDK17プロジェクト/コード/03.サウンド/CSoundDeviceASIO.cs
+++ b/FDK17プロジェクト/コード/03.サウンド/CSoundDeviceASIO.cs
@@ -154,9 +154,15 @@ namespace FDK
 			// BASS の設定。
 
 			this.bIsBASSFree = true;
-			Debug.Assert( Bass.BASS_SetConfig( BASSConfig.BASS_CONFIG_UPDATEPERIOD, 0 ),		// 0:BASSストリームの自動更新を行わない。（BASSWASAPIから行うため）
-				string.Format( "BASS_SetConfig() に失敗しました。[{0}", Bass.BASS_ErrorGetCode() ) );
 
+		    if (!Bass.BASS_SetConfig( BASSConfig.BASS_CONFIG_UPDATEPERIOD, 0 )) // 0:BASSストリームの自動更新を行わない。
+		    {
+		        Trace.TraceWarning($"BASS_SetConfig({nameof(BASSConfig.BASS_CONFIG_UPDATEPERIOD)}) に失敗しました。[{Bass.BASS_ErrorGetCode()}]");
+		    }
+		    if (!Bass.BASS_SetConfig( BASSConfig.BASS_CONFIG_UPDATETHREADS, 0 )) // 0:BASSストリームの自動更新を行わない。
+		    {
+		        Trace.TraceWarning($"BASS_SetConfig({nameof(BASSConfig.BASS_CONFIG_UPDATETHREADS)}) に失敗しました。[{Bass.BASS_ErrorGetCode()}]");
+		    }
 		
 			// BASS の初期化。
 

--- a/FDK17プロジェクト/コード/03.サウンド/CSoundDeviceWASAPI.cs
+++ b/FDK17プロジェクト/コード/03.サウンド/CSoundDeviceWASAPI.cs
@@ -146,9 +146,15 @@ namespace FDK
 			// BASS の設定。
 
 			this.bIsBASSFree = true;
-			Debug.Assert( Bass.BASS_SetConfig( BASSConfig.BASS_CONFIG_UPDATEPERIOD, 0 ),		// 0:BASSストリームの自動更新を行わない。（BASSWASAPIから行うため）
-				string.Format( "BASS_SetConfig() に失敗しました。[{0}", Bass.BASS_ErrorGetCode() ) );
 
+		    if (!Bass.BASS_SetConfig( BASSConfig.BASS_CONFIG_UPDATEPERIOD, 0 )) // 0:BASSストリームの自動更新を行わない。
+		    {
+		        Trace.TraceWarning($"BASS_SetConfig({nameof(BASSConfig.BASS_CONFIG_UPDATEPERIOD)}) に失敗しました。[{Bass.BASS_ErrorGetCode()}]");
+		    }
+		    if (!Bass.BASS_SetConfig( BASSConfig.BASS_CONFIG_UPDATETHREADS, 0 )) // 0:BASSストリームの自動更新を行わない。
+		    {
+		        Trace.TraceWarning($"BASS_SetConfig({nameof(BASSConfig.BASS_CONFIG_UPDATETHREADS)}) に失敗しました。[{Bass.BASS_ErrorGetCode()}]");
+		    }
 
 			// BASS の初期化。
 

--- a/FDK17プロジェクト/コード/03.サウンド/LoudnessMetadataScanner.cs
+++ b/FDK17プロジェクト/コード/03.サウンド/LoudnessMetadataScanner.cs
@@ -121,7 +121,17 @@ namespace FDK
 
         private static LoudnessMetadata? LoadFromMetadataPath(string loudnessMetadataPath)
         {
-            var xPathDocument = new XPathDocument(loudnessMetadataPath);
+            XPathDocument xPathDocument;
+            try
+            {
+                xPathDocument = new XPathDocument(loudnessMetadataPath);
+            }
+            catch (IOException)
+            {
+                var tracePrefix = $"{nameof(LoudnessMetadataScanner)}.{nameof(LoadFromMetadataPath)}";
+                Trace.TraceWarning($"{tracePrefix}: Encountered IOException while attempting to read {loudnessMetadataPath}. This can occur when attempting to load while scanning the same file. Returning null...");
+                return null;
+            }
 
             var trackNavigator = xPathDocument.CreateNavigator()
                 .SelectSingleNode(@"//bs1770gain/album/track[@total=""1"" and @number=""1""]");


### PR DESCRIPTION
General fixes and improvements intended to load various files and parse tja files more safely and flexibly, to reduce unnecessary entries in the log file, and to add more helpful information to the log file.

You may wish to review this pull request by first reading the diffs of each commit, as each commit includes a separate set of related changes, and each commit should be easy to review on its own.

Note that a number of new strings have been added which would benefit from translation into Japanese. I have indicated them with "[i18n]".

**.tja parsing improvements**
* Safer header/command parameter parsing with more diagnostic output upon encountering problems
* Deduplicated normal, expert, and master BALLOON parsing.

**Reduced log noise**
* Safer attempts to read *.dtx.score.ini files.
* Check for the existence of the songlist.db file before attempting to read it.
* Changed a texture loading logged error (with stack trace) into a logged warning (with just a message.)
* Changed a private font loading logged error (with stack trace) into a logged warning (with just a message.)
* LoudnessMetadataScanner now more cleanly warns upon IOExceptions encountered when trying to load metadata files.
* After review of CSkin.t読み込み call sites, changed FileNotFoundException throw into a trace warning and early return.

**Additional/improved diagnostic log output**
* Added a little diagnostic logging when a file does not include at least one #START command.
* Added a little diagnostic logging when a header cannot be split into name and value.
* Add discriminating text to the most-often-logged identical trace error messages (at least until we can upgrade things to get accurate stack traces in all cases. Something is currently preventing TJAPlayer3 from always generating accurate stack traces.)
* Simplified trace warnings about system sounds which could not be found on disk.
* In CSkin, upgraded a pattern of basic Int32 parsing so that when parsing fails some trace warning output describing the failure will be produced.
* CSound now logs a trace warning when a sound file does not exist for loading.

**General fixes and improvements**
* Earlier, safer disposal of private font resources and temporary bitmaps (created using said fonts and then loaded into textures)
* ASIO and WASAPI now correctly set update period to 0 and update threads to 0.
* Fixed a number of (small) memory leaks, most related to dynamic text and dummy 1x1 bitmaps.