### PR TITLE
Interactive input calibration with automatic update of Config.ini InputAdjustTime

### DIFF
--- a/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelect曲リスト.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/05.選曲/CActSelect曲リスト.cs
@@ -527,6 +527,10 @@ namespace DTXMania
 			if( this.b活性化してる )
 				return;
 
+            // Reset to not performing calibration each time we
+            // enter or return to the song select screen.
+		    CDTXMania.IsPerformingCalibration = false;
+
             if (!string.IsNullOrEmpty(CDTXMania.ConfigIni.FontName))
             {
                 this.pfMusicName = new CPrivateFastFont(new FontFamily(CDTXMania.ConfigIni.FontName), 28);

--- a/DTXManiaプロジェクト/コード/ステージ/06.曲読み込み/CStage曲読み込み.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/06.曲読み込み/CStage曲読み込み.cs
@@ -52,17 +52,51 @@ namespace DTXMania
 					this.sd読み込み音 = null;
 				}
 
-				string strDTXファイルパス = ( CDTXMania.bコンパクトモード ) ?
-					CDTXMania.strコンパクトモードファイル : CDTXMania.stage選曲.r確定されたスコア.ファイル情報.ファイルの絶対パス;
+			    if (CDTXMania.bコンパクトモード)
+			    {
+			        string strDTXファイルパス = CDTXMania.strコンパクトモードファイル;
 				
-				CDTX cdtx = new CDTX( strDTXファイルパス, true, 1.0, 0, 0 );
-                if( File.Exists( cdtx.strフォルダ名 + @"set.def" ) )
-				    cdtx = new CDTX( strDTXファイルパス, true, 1.0, 0, 1 );
+			        CDTX cdtx = new CDTX( strDTXファイルパス, true, 1.0, 0, 0 );
+			        if( File.Exists( cdtx.strフォルダ名 + @"set.def" ) )
+			            cdtx = new CDTX( strDTXファイルパス, true, 1.0, 0, 1 );
 
-				this.str曲タイトル = cdtx.TITLE;
-                this.strサブタイトル = cdtx.SUBTITLE;
+			        this.str曲タイトル = cdtx.TITLE;
+			        this.strサブタイトル = cdtx.SUBTITLE;
+
+			        cdtx.On非活性化();
+			    }
+			    else
+			    {
+			        string strDTXファイルパス = CDTXMania.stage選曲.r確定されたスコア.ファイル情報.ファイルの絶対パス;
+
+			        var strフォルダ名 = Path.GetDirectoryName(strDTXファイルパス) + @"\";
+
+			        if (File.Exists(strフォルダ名 + @"set.def"))
+			        {
+			            var cdtx = new CDTX(strDTXファイルパス, true, 1.0, 0, 1);
+
+			            this.str曲タイトル = cdtx.TITLE;
+			            this.strサブタイトル = cdtx.SUBTITLE;
+
+			            cdtx.On非活性化();
+			        }
+			        else
+			        {
+			            var 譜面情報 = CDTXMania.stage選曲.r確定されたスコア.譜面情報;
+			            this.str曲タイトル = 譜面情報.タイトル;
+			            this.strサブタイトル = 譜面情報.strサブタイトル;
+			        }
+			    }
+
+                // For the moment, detect that we are performing
+                // calibration via the special song title and subtitle
+                // of the .tja used to perform input calibration
+			    CDTXMania.IsPerformingCalibration =
+			        str曲タイトル == "Input Calibration" &&
+			        strサブタイトル == "TJAPlayer3 Developers";
+
 				this.strSTAGEFILE = CSkin.Path(@"Graphics\4_SongLoading\Background.png");
-				cdtx.On非活性化();
+
 				base.On活性化();
 			}
 			finally
@@ -97,18 +131,30 @@ namespace DTXMania
                 this.ct曲名表示 = new CCounter( 1, 30, 30, CDTXMania.Timer );
 				try
 				{
-					if( ( this.str曲タイトル != null ) && ( this.str曲タイトル.Length > 0 ) )
+                    // When performing calibration, inform the player that
+                    // calibration is about to begin, rather than
+                    // displaying the song title and subtitle as usual.
+
+				    var タイトル = CDTXMania.IsPerformingCalibration
+				        ? "Input calibration is about to begin."
+				        : this.str曲タイトル;
+
+				    var サブタイトル = CDTXMania.IsPerformingCalibration
+				        ? "Please play as accurately as possible."
+				        : this.strサブタイトル;
+
+				    if( !string.IsNullOrEmpty(タイトル) )
 					{
                         //this.txタイトル = new CTexture( CDTXMania.app.Device, image, CDTXMania.TextureFormat );
                         //this.txタイトル.vc拡大縮小倍率 = new Vector3( 0.5f, 0.5f, 1f );
 
-					    using (var bmpSongTitle = this.pfTITLE.DrawPrivateFont( this.str曲タイトル, Color.White, Color.Black ))
+					    using (var bmpSongTitle = this.pfTITLE.DrawPrivateFont( タイトル, Color.White, Color.Black ))
 					    {
 					        this.txタイトル = new CTexture( CDTXMania.app.Device, bmpSongTitle, CDTXMania.TextureFormat, false );
 					        txタイトル.vc拡大縮小倍率.X = CDTXMania.GetSongNameXScaling(ref txタイトル, 710);
 					    }
 
-					    using (var bmpSongSubTitle = this.pfSUBTITLE.DrawPrivateFont( this.strサブタイトル, Color.White, Color.Black ))
+					    using (var bmpSongSubTitle = this.pfSUBTITLE.DrawPrivateFont( サブタイトル, Color.White, Color.Black ))
 					    {
 					        this.txサブタイトル = new CTexture( CDTXMania.app.Device, bmpSongSubTitle, CDTXMania.TextureFormat, false );
 					    }
@@ -265,7 +311,6 @@ namespace DTXMania
                                 if( CDTXMania.ConfigIni.nPlayerCount == 2 )
 						            CDTXMania.DTX_2P = new CDTX( str, false, ( (double) CDTXMania.ConfigIni.n演奏速度 ) / 20.0, ini.stファイル.BGMAdjust, 0, 1, true );
                             }
-
 
 					    	Trace.TraceInformation( "----曲情報-----------------" );
 				    		Trace.TraceInformation( "TITLE: {0}", CDTXMania.DTX.TITLE );

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CAct演奏判定文字列共通.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CAct演奏判定文字列共通.cs
@@ -80,6 +80,13 @@ namespace DTXMania
 
 		public virtual void Start( int nLane, E判定 judge, int lag, CDTX.CChip pChip, int player )
 		{
+		    // When performing calibration, reduce visual distraction
+		    // and current judgment feedback near the judgment position.
+		    if (CDTXMania.IsPerformingCalibration)
+		    {
+		        return;
+		    }
+
             if( pChip.nチャンネル番号 >= 0x15 && pChip.nチャンネル番号 <= 0x19 )
             {
                 return;

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CLagLogger.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CLagLogger.cs
@@ -37,11 +37,11 @@ namespace DTXMania
             LagValues.Add(pChipNLag);
         }
 
-        public static void Log()
+        public static double? LogAndReturnMeanLag()
         {
-            if (LagValues.Count == 0)
+            if (LagValues.Count < 30)
             {
-                return;
+                return null;
             }
 
             var orderedLagValues = LagValues.OrderBy(x => x).ToList();
@@ -55,7 +55,7 @@ namespace DTXMania
             var stdev = Math.Sqrt(orderedLagValues.Select(o => Math.Pow(o - mean, 2)).Average());
 
             Trace.TraceInformation(
-                $"{nameof(CLagLogger)}.{nameof(Log)}: Mean lag: {mean}. Median lag: {median}. Mode(s) of lag: {modes}. Standard deviation of lag: {stdev}.");
+                $"{nameof(CLagLogger)}.{nameof(LogAndReturnMeanLag)}: Mean lag: {mean}. Median lag: {median}. Mode(s) of lag: {modes}. Standard deviation of lag: {stdev}.");
 
             var hitChipCountsIndexedByOffsetLag = new int[1 + MaximumLag + 1 + MaximumLag + 1];
             foreach (var pChipNLag in LagValues)
@@ -102,9 +102,11 @@ namespace DTXMania
             }
 
             Trace.TraceInformation(
-                $"{nameof(CLagLogger)}.{nameof(Log)}: Hit chip counts, indexed by lag in milliseconds:{Environment.NewLine}{sbHeader}{Environment.NewLine}{sbData}");
+                $"{nameof(CLagLogger)}.{nameof(LogAndReturnMeanLag)}: Hit chip counts, indexed by lag in milliseconds:{Environment.NewLine}{sbHeader}{Environment.NewLine}{sbData}");
 
             LagValues.Clear();
+
+            return mean;
         }
     }
 }

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CStage演奏画面共通.cs
@@ -352,7 +352,15 @@ namespace DTXMania
 			cInvisibleChip = null;
 //			GCSettings.LatencyMode = this.gclatencymode;
 
-			CLagLogger.Log();
+			var meanLag = CLagLogger.LogAndReturnMeanLag();
+
+		    if (CDTXMania.IsPerformingCalibration && meanLag != null)
+		    {
+		        var oldInputAdjustTimeMs = CDTXMania.ConfigIni.nInputAdjustTimeMs;
+		        var newInputAdjustTimeMs = oldInputAdjustTimeMs - (int) Math.Round(meanLag.Value);
+		        Trace.TraceInformation($"Calibration complete. Updating InputAdjustTime from {oldInputAdjustTimeMs}ms to {newInputAdjustTimeMs}ms.");
+		        CDTXMania.ConfigIni.nInputAdjustTimeMs = newInputAdjustTimeMs;
+		    }
 
             base.On非活性化();
 		}
@@ -791,7 +799,32 @@ namespace DTXMania
 			}
 		}
 
-		protected E判定 e指定時刻からChipのJUDGEを返す( long nTime, CDTX.CChip pChip )
+	    internal E判定 e指定時刻からChipのJUDGEを返す(long nTime, CDTX.CChip pChip)
+	    {
+	        var e判定 = e指定時刻からChipのJUDGEを返すImpl(nTime, pChip);
+
+	        // When performing calibration, reduce audio distraction from user input.
+            // For users who play primarily by watching notes cross the judgment position,
+	        // you might think that we want them to see visual judgment feedback during
+	        // calibration, but we do not. Humans are remarkably good at adjusting
+	        // the timing of their own physical movement, even without realizing it.
+	        // We are calibrating their input timing for the purposes of judgment.
+	        // We do not want them subconsciously playing early so as to line up
+	        // their hits with the perfect, good, etc. judgment results based on their
+	        // current (and soon to be replaced) input adjust time values.
+	        // Instead, we want them focused on the sounds of their keyboard, tatacon,
+	        // other controller, etc. and the visuals of notes crossing the judgment position.
+	        if (CDTXMania.IsPerformingCalibration)
+	        {
+	            return e判定 < E判定.Good ? E判定.Good : e判定;
+	        }
+            else
+	        {
+	            return e判定;
+	        }
+	    }
+
+	    private E判定 e指定時刻からChipのJUDGEを返すImpl( long nTime, CDTX.CChip pChip )
 		{
 			if ( pChip != null )
 			{
@@ -1020,11 +1053,11 @@ namespace DTXMania
 		{
 			int index = pChip.nチャンネル番号;
             if( index == 0x11 || index == 0x13 || index == 0x1A )
-                this.soundRed.t再生を開始する();
+                this.soundRed?.t再生を開始する();
             else if( index == 0x12 || index == 0x14 || index == 0x1B )
-                this.soundBlue.t再生を開始する();
+                this.soundBlue?.t再生を開始する();
             else if( index == 0x1F )
-                this.soundAdlib.t再生を開始する();
+                this.soundAdlib?.t再生を開始する();
 
             if( this.nHand[ nPlayer ] == 0 )
                 this.nHand[ nPlayer ]++;
@@ -1135,7 +1168,7 @@ namespace DTXMania
                 //赤か青かの分岐
                 if( sort == 0 )
                 {
-                    this.soundRed.t再生を開始する();
+                    this.soundRed?.t再生を開始する();
                     if( pChip.nチャンネル番号 == 0x15 )
                     {
                         //CDTXMania.Skin.soundRed.t再生する();
@@ -1151,7 +1184,7 @@ namespace DTXMania
                 }
                 else
                 {
-                    this.soundBlue.t再生を開始する();
+                    this.soundBlue?.t再生を開始する();
                     if( pChip.nチャンネル番号 == 0x15 )
                     {
                         //CDTXMania.Skin.soundBlue.t再生する();
@@ -1250,7 +1283,7 @@ namespace DTXMania
                         this.actScore.Add(E楽器パート.TAIKO, this.bIsAutoPlay, 300L, player);
                     }
                     //CDTXMania.Skin.soundRed.t再生する();
-                    this.soundRed.t再生を開始する();
+                    this.soundRed?.t再生を開始する();
                 }
             }
             else
@@ -2754,7 +2787,15 @@ namespace DTXMania
 		}
 		protected void tパネル文字列の設定()
 		{
-			this.actPanel.SetPanelString( string.IsNullOrEmpty( CDTXMania.DTX.PANEL ) ? CDTXMania.DTX.TITLE : CDTXMania.DTX.PANEL );
+		    // When performing calibration, inform the player that
+		    // calibration is taking place, rather than
+		    // displaying the panel title or song title as usual.
+
+		    var panelString = CDTXMania.IsPerformingCalibration
+                ? "Calibrating input..."
+                : string.IsNullOrEmpty( CDTXMania.DTX.PANEL ) ? CDTXMania.DTX.TITLE: CDTXMania.DTX.PANEL;
+
+		    this.actPanel.SetPanelString( panelString );
 		}
 
 

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CAct演奏DrumsチップファイアD.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CAct演奏DrumsチップファイアD.cs
@@ -253,7 +253,10 @@ namespace DTXMania
 						        this.st状態[ i ].ct進行.t停止();
                                 this.st状態[ i ].b使用中 = false;
 					        }
-					        if( CDTXMania.Tx.Effects_Hit_Explosion != null )
+
+                            // (When performing calibration, reduce visual distraction
+                            // and current judgment feedback near the judgment position.)
+					        if( CDTXMania.Tx.Effects_Hit_Explosion != null && !CDTXMania.IsPerformingCalibration )
 					        {
                                 int n = this.st状態[ i ].nIsBig == 1 ? 520 : 0;
                                 int nX = ( CDTXMania.Skin.nScrollFieldX[ this.st状態[ i ].nPlayer ] ) - ( (CDTXMania.Tx.Effects_Hit_Explosion.sz画像サイズ.Width / 7 ) / 2 );

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/ドラム画面/CStage演奏ドラム画面.cs
@@ -295,11 +295,24 @@ namespace DTXMania
 
     //            this.tx判定数表示パネル = CDTXMania.tテクスチャの生成( CSkin.Path( @"Graphics\7_Paramater Panel.png" ) );
 
-                this.soundRed = CDTXMania.Sound管理.tサウンドを生成する( CSkin.Path( @"Sounds\Taiko\dong.ogg" ), ESoundGroup.SoundEffect );
-                this.soundBlue = CDTXMania.Sound管理.tサウンドを生成する( CSkin.Path( @"Sounds\Taiko\ka.ogg" ), ESoundGroup.SoundEffect );
-                this.soundAdlib = CDTXMania.Sound管理.tサウンドを生成する( CSkin.Path(@"Sounds\Taiko\Adlib.ogg"), ESoundGroup.SoundEffect );
+			    // When performing calibration, reduce audio distraction from user input.
+			    // For users who play primarily by listening to the music,
+                // you might think that we want them to hear drum sound effects during
+                // calibration, but we do not. Humans are remarkably good at adjusting
+                // the timing of their own physical movement, even without realizing it.
+			    // We are calibrating their input timing for the purposes of judgment.
+                // We do not want them subconsciously playing early so as to line up
+                // their drum sound effects with the sounds of the input calibration file.
+                // Instead, we want them focused on the sounds of their keyboard, tatacon,
+                // other controller, etc. and the sounds of the input calibration audio file.
+			    if (!CDTXMania.IsPerformingCalibration)
+			    {
+			        this.soundRed = CDTXMania.Sound管理.tサウンドを生成する( CSkin.Path( @"Sounds\Taiko\dong.ogg" ), ESoundGroup.SoundEffect );
+			        this.soundBlue = CDTXMania.Sound管理.tサウンドを生成する( CSkin.Path( @"Sounds\Taiko\ka.ogg" ), ESoundGroup.SoundEffect );
+			        this.soundAdlib = CDTXMania.Sound管理.tサウンドを生成する( CSkin.Path(@"Sounds\Taiko\Adlib.ogg"), ESoundGroup.SoundEffect );
+			    }
 
-				base.OnManagedリソースの作成();
+			    base.OnManagedリソースの作成();
 			}
 		}
 		public override void OnManagedリソースの解放()
@@ -876,7 +889,7 @@ namespace DTXMania
                             b太鼓音再生フラグ = false;
 
                         if( chipNoHit.nチャンネル番号 == 0x1F && ( e判定 != E判定.Miss && e判定 != E判定.Poor ) )
-                            this.soundAdlib.t再生を開始する();
+                            this.soundAdlib?.t再生を開始する();
                     }
 
                     switch (nPad)
@@ -887,7 +900,7 @@ namespace DTXMania
                             nChannel = 0x11;
                             if( b太鼓音再生フラグ )
                             {
-                                this.soundRed.t再生を開始する();
+                                this.soundRed?.t再生を開始する();
                             }
                             break;
                         case 13:
@@ -896,7 +909,7 @@ namespace DTXMania
                             nChannel = 0x11;
                             if( b太鼓音再生フラグ )
                             {
-                                this.soundRed.t再生を開始する();
+                                this.soundRed?.t再生を開始する();
                             }
                             break;
                         case 14:
@@ -904,14 +917,14 @@ namespace DTXMania
                             nHand = 0;
                             nChannel = 0x12;
                             if( b太鼓音再生フラグ )
-                                this.soundBlue.t再生を開始する();
+                                this.soundBlue?.t再生を開始する();
                             break;
                         case 15:
                             nLane = 1;
                             nHand = 1;
                             nChannel = 0x12;
                             if( b太鼓音再生フラグ )
-                                this.soundBlue.t再生を開始する();
+                                this.soundBlue?.t再生を開始する();
                             break;
                         //以下2P
                         case 16:
@@ -920,7 +933,7 @@ namespace DTXMania
                             nChannel = 0x11;
                             if( b太鼓音再生フラグ )
                             {
-                                this.soundRed.t再生を開始する();
+                                this.soundRed?.t再生を開始する();
                             }
                             break;
                         case 17:
@@ -929,7 +942,7 @@ namespace DTXMania
                             nChannel = 0x11;
                             if( b太鼓音再生フラグ )
                             {
-                                this.soundRed.t再生を開始する();
+                                this.soundRed?.t再生を開始する();
                             }
                             break;
                         case 18:
@@ -937,14 +950,14 @@ namespace DTXMania
                             nHand = 0;
                             nChannel = 0x12;
                             if( b太鼓音再生フラグ )
-                                this.soundBlue.t再生を開始する();
+                                this.soundBlue?.t再生を開始する();
                             break;
                         case 19:
                             nLane = 1;
                             nHand = 1;
                             nChannel = 0x12;
                             if( b太鼓音再生フラグ )
-                                this.soundBlue.t再生を開始する();
+                                this.soundBlue?.t再生を開始する();
                             break;
                     }
 

--- a/DTXManiaプロジェクト/コード/ステージ/08.結果/CActResultSongBar.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/08.結果/CActResultSongBar.cs
@@ -41,8 +41,15 @@ namespace DTXMania
                 this.pfStageText = new CPrivateFastFont(new FontFamily("MS UI Gothic"), 30);
             }
 
+		    // After performing calibration, inform the player that
+		    // calibration has been completed, rather than
+		    // displaying the song title as usual.
 
-		    using (var bmpSongTitle = pfMusicName.DrawPrivateFont(CDTXMania.DTX.TITLE, Color.White, Color.Black))
+		    var title = CDTXMania.IsPerformingCalibration
+		        ? $"Calibration complete. InputAdjustTime is now {CDTXMania.ConfigIni.nInputAdjustTimeMs}ms"
+		        : CDTXMania.DTX.TITLE;
+
+		    using (var bmpSongTitle = pfMusicName.DrawPrivateFont(title, Color.White, Color.Black))
 		    {
 		        this.txMusicName = CDTXMania.tテクスチャの生成(bmpSongTitle, false);
 		        txMusicName.vc拡大縮小倍率.X = CDTXMania.GetSongNameXScaling(ref txMusicName);

--- a/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
+++ b/DTXManiaプロジェクト/コード/全体/CDTXMania.cs
@@ -88,6 +88,9 @@ namespace DTXMania
 				}
 			}
 		}
+
+	    public static bool IsPerformingCalibration;
+
 		public static CFPS FPS
 		{ 
 			get; 


### PR DESCRIPTION
InputAdjustTime is now updated automatically simply by playing a specially-titled input calibration song.
* Modified on-screen text before, during, and after calibration helps the user understand what is happening.
* Drum sound effects are silenced during calibration so the user focuses on the correct timing.
* Visual judgment feedback is reduced during calibration so the user focuses on the correct timing.