### PR TITLE
SkinConfigや文字に関するいくつかの変更（n回目）

### DIFF
--- a/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CActConfigList.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CActConfigList.cs
@@ -1805,7 +1805,7 @@ namespace DTXMania
 				//-----------------
 				if ( listMenu[ nItem ].txMenuItemRight != null )	// 自前のキャッシュに含まれているようなら、再レンダリングせずキャッシュを使用
 				{
-                    listMenu[nItem].txMenuItemRight.t2D描画(CDTXMania.app.Device, x + 20 + CDTXMania.Skin.Config_ItemText_Correction_X, y + 12 + CDTXMania.Skin.Config_ItemText_Correction_Y);
+                    listMenu[nItem].txMenuItemRight.t2D描画(CDTXMania.app.Device, x + 20 + CDTXMania.Skin.Config_ItemText_Correction_XY[0], y + 12 + CDTXMania.Skin.Config_ItemText_Correction_XY[1]);
 				}
 				else
 				{
@@ -1910,7 +1910,7 @@ namespace DTXMania
 				    {
 				        using (var txStr = CDTXMania.tテクスチャの生成( bmpStr, false ))
 				        {
-				            txStr.t2D描画( CDTXMania.app.Device, x + 400 + CDTXMania.Skin.Config_ItemText_Correction_X, y + 12 + CDTXMania.Skin.Config_ItemText_Correction_Y );
+				            txStr.t2D描画( CDTXMania.app.Device, x + 400 + CDTXMania.Skin.Config_ItemText_Correction_XY[0], y + 12 + CDTXMania.Skin.Config_ItemText_Correction_XY[1] );
 				        }
 				    }
 				}
@@ -1931,7 +1931,7 @@ namespace DTXMania
 
 						listMenu[ nItem ] = stm;
 					}
-					listMenu[ nItem ].txParam.t2D描画( CDTXMania.app.Device,  x + 400 + CDTXMania.Skin.Config_ItemText_Correction_X, y + 12 + CDTXMania.Skin.Config_ItemText_Correction_Y );
+					listMenu[ nItem ].txParam.t2D描画( CDTXMania.app.Device,  x + 400 + CDTXMania.Skin.Config_ItemText_Correction_XY[0], y + 12 + CDTXMania.Skin.Config_ItemText_Correction_XY[1] );
 				}
 				//-----------------
 				#endregion

--- a/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CStageコンフィグ.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/04.コンフィグ/CStageコンフィグ.cs
@@ -229,7 +229,7 @@ namespace DTXMania
 				//txMenuItemLeft = CDTXMania.tテクスチャの生成( bmpStr, false );
 				int flag = ( this.n現在のメニュー番号 == i ) ? 1 : 0;
 				int num4 = txMenuItemLeft[ i, flag ].sz画像サイズ.Width;
-                txMenuItemLeft[i, flag].t2D描画(CDTXMania.app.Device, 282 - (num4 / 2) + CDTXMania.Skin.Config_ItemText_Correction_X, menuY + CDTXMania.Skin.Config_ItemText_Correction_Y ); //55
+                txMenuItemLeft[i, flag].t2D描画(CDTXMania.app.Device, 282 - (num4 / 2) + CDTXMania.Skin.Config_ItemText_Correction_XY[0], menuY + CDTXMania.Skin.Config_ItemText_Correction_XY[1] ); //55
 				//txMenuItem.Dispose();
 				menuY += stepY;
 			}

--- a/DTXManiaプロジェクト/コード/ステージ/06.曲読み込み/CStage曲読み込み.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/06.曲読み込み/CStage曲読み込み.cs
@@ -263,15 +263,15 @@ namespace DTXMania
                 CDTXMania.Tx.SongLoading_Plate.n透明度 = C変換.nParsentTo255((this.ct曲名表示.n現在の値 / 30.0));
                 if(CDTXMania.Skin.SongLoading_Plate_ReferencePoint == CSkin.ReferencePoint.Left)
                 {
-                CDTXMania.Tx.SongLoading_Plate.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Plate_X, CDTXMania.Skin.SongLoading_Plate_Y - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
+                CDTXMania.Tx.SongLoading_Plate.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Plate_XY[0], CDTXMania.Skin.SongLoading_Plate_XY[1] - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
                 }
                 else if(CDTXMania.Skin.SongLoading_Plate_ReferencePoint == CSkin.ReferencePoint.Right)
                 {
-                CDTXMania.Tx.SongLoading_Plate.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Plate_X - CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Width, CDTXMania.Skin.SongLoading_Plate_Y - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
+                CDTXMania.Tx.SongLoading_Plate.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Plate_XY[0] - CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Width, CDTXMania.Skin.SongLoading_Plate_XY[1] - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
                 }
                 else
                 {
-                CDTXMania.Tx.SongLoading_Plate.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Plate_X - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Width / 2), CDTXMania.Skin.SongLoading_Plate_Y - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
+                CDTXMania.Tx.SongLoading_Plate.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Plate_XY[0] - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Width / 2), CDTXMania.Skin.SongLoading_Plate_XY[1] - (CDTXMania.Tx.SongLoading_Plate.sz画像サイズ.Height / 2));
                 }
             }
             //CDTXMania.act文字コンソール.tPrint( 0, 16, C文字コンソール.Eフォント種別.灰, C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) ).ToString() );
@@ -285,15 +285,15 @@ namespace DTXMania
                 this.txタイトル.n透明度 = C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) );
                 if(CDTXMania.Skin.SongLoading_Title_ReferencePoint == CSkin.ReferencePoint.Left)
                 {
-                    this.txタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Title_X, CDTXMania.Skin.SongLoading_Title_Y - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
+                    this.txタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Title_XY[0], CDTXMania.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
                 }
                 else if(CDTXMania.Skin.SongLoading_Title_ReferencePoint == CSkin.ReferencePoint.Right)
                 {
-                    this.txタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Title_X - (this.txタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X), CDTXMania.Skin.SongLoading_Title_Y - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
+                    this.txタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_Title_XY[0] - (this.txタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X), CDTXMania.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
                 }
                 else
                 {
-                    this.txタイトル.t2D描画(CDTXMania.app.Device, (CDTXMania.Skin.SongLoading_Title_X - ((this.txタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X) / 2)), CDTXMania.Skin.SongLoading_Title_Y - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
+                    this.txタイトル.t2D描画(CDTXMania.app.Device, (CDTXMania.Skin.SongLoading_Title_XY[0] - ((this.txタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X) / 2)), CDTXMania.Skin.SongLoading_Title_XY[1] - (this.txタイトル.sz画像サイズ.Height / 2) + nサブタイトル補正);
                 }
             }
 			if( this.txサブタイトル != null )
@@ -301,15 +301,15 @@ namespace DTXMania
                 this.txサブタイトル.n透明度 = C変換.nParsentTo255( ( this.ct曲名表示.n現在の値 / 30.0 ) );
                 if(CDTXMania.Skin.SongLoading_SubTitle_ReferencePoint == CSkin.ReferencePoint.Left)
                 {
-                    this.txサブタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_SubTitle_X, CDTXMania.Skin.SongLoading_SubTitle_Y - (this.txサブタイトル.sz画像サイズ.Height / 2));
+                    this.txサブタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_SubTitle_XY[0], CDTXMania.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
                 }
                 else if(CDTXMania.Skin.SongLoading_Title_ReferencePoint == CSkin.ReferencePoint.Right)
                 {
-                    this.txサブタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_SubTitle_X - (this.txサブタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X), CDTXMania.Skin.SongLoading_SubTitle_Y - (this.txサブタイトル.sz画像サイズ.Height / 2));
+                    this.txサブタイトル.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.SongLoading_SubTitle_XY[0] - (this.txサブタイトル.sz画像サイズ.Width * txタイトル.vc拡大縮小倍率.X), CDTXMania.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
                 }
                 else
                 {
-                    this.txサブタイトル.t2D描画(CDTXMania.app.Device, (CDTXMania.Skin.SongLoading_SubTitle_X - ((this.txサブタイトル.sz画像サイズ.Width * txサブタイトル.vc拡大縮小倍率.X) / 2)), CDTXMania.Skin.SongLoading_SubTitle_Y - (this.txサブタイトル.sz画像サイズ.Height / 2));
+                    this.txサブタイトル.t2D描画(CDTXMania.app.Device, (CDTXMania.Skin.SongLoading_SubTitle_XY[0] - ((this.txサブタイトル.sz画像サイズ.Width * txサブタイトル.vc拡大縮小倍率.X) / 2)), CDTXMania.Skin.SongLoading_SubTitle_XY[1] - (this.txサブタイトル.sz画像サイズ.Height / 2));
                 }
             }
 			//-----------------------------

--- a/DTXManiaプロジェクト/コード/ステージ/07.演奏/CAct演奏パネル文字列.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/07.演奏/CAct演奏パネル文字列.cs
@@ -148,15 +148,15 @@ namespace DTXMania
             {
                 if (CDTXMania.Skin.Game_Lyric_ReferencePoint == CSkin.ReferencePoint.Left)
                 {
-                this.tx歌詞テクスチャ.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_Lyric_X , CDTXMania.Skin.Game_Lyric_Y);
+                this.tx歌詞テクスチャ.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_Lyric_XY[0] , CDTXMania.Skin.Game_Lyric_XY[1]);
                 }
                 else if (CDTXMania.Skin.Game_Lyric_ReferencePoint == CSkin.ReferencePoint.Right)
                 {
-                this.tx歌詞テクスチャ.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_Lyric_X - this.tx歌詞テクスチャ.szテクスチャサイズ.Width, CDTXMania.Skin.Game_Lyric_Y);
+                this.tx歌詞テクスチャ.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_Lyric_XY[0] - this.tx歌詞テクスチャ.szテクスチャサイズ.Width, CDTXMania.Skin.Game_Lyric_XY[1]);
                 }
                 else
                 {
-                this.tx歌詞テクスチャ.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_Lyric_X - (this.tx歌詞テクスチャ.szテクスチャサイズ.Width / 2), CDTXMania.Skin.Game_Lyric_Y);
+                this.tx歌詞テクスチャ.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_Lyric_XY[0] - (this.tx歌詞テクスチャ.szテクスチャサイズ.Width / 2), CDTXMania.Skin.Game_Lyric_XY[1]);
                 }
             }
         }
@@ -239,7 +239,7 @@ namespace DTXMania
                     this.ct進行用.n現在の値 = 300;
                 }
                 if( this.txGENRE != null )
-                    this.txGENRE.t2D描画( CDTXMania.app.Device, CDTXMania.Skin.Game_Genre_X, CDTXMania.Skin.Game_Genre_Y );
+                    this.txGENRE.t2D描画( CDTXMania.app.Device, CDTXMania.Skin.Game_Genre_XY[0], CDTXMania.Skin.Game_Genre_XY[1] );
 
                 if( CDTXMania.Skin.b現在のステージ数を表示しない )
                 {
@@ -251,15 +251,15 @@ namespace DTXMania
                         this.txMusicName.vc拡大縮小倍率.X = fRate;
                         if (CDTXMania.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
                         {
-                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X - ((this.txMusicName.szテクスチャサイズ.Width * fRate) / 2), CDTXMania.Skin.Game_MusicName_Y);
+                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * fRate) / 2), CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                         else if (CDTXMania.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
                         {
-                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X, CDTXMania.Skin.Game_MusicName_Y);
+                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0], CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                         else
                         {
-                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X - (this.txMusicName.szテクスチャサイズ.Width * fRate), CDTXMania.Skin.Game_MusicName_Y);
+                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0] - (this.txMusicName.szテクスチャサイズ.Width * fRate), CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                     }
                 }
@@ -306,29 +306,29 @@ namespace DTXMania
                         }
                         if (CDTXMania.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
                         {
-                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), CDTXMania.Skin.Game_MusicName_Y);
+                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                         else if (CDTXMania.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
                         {
-                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X, CDTXMania.Skin.Game_MusicName_Y);
+                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0], CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                         else
                         {
-                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X - (this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X), CDTXMania.Skin.Game_MusicName_Y);
+                            this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0] - (this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X), CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                     }
                     if (this.tx難易度とステージ数 != null)
                         if (CDTXMania.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
                         {
-                            this.tx難易度とステージ数.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X - (this.tx難易度とステージ数.szテクスチャサイズ.Width / 2), CDTXMania.Skin.Game_MusicName_Y);
+                            this.tx難易度とステージ数.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0] - (this.tx難易度とステージ数.szテクスチャサイズ.Width / 2), CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                         else if (CDTXMania.Skin.Game_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
                         {
-                            this.tx難易度とステージ数.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X, CDTXMania.Skin.Game_MusicName_Y);
+                            this.tx難易度とステージ数.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0], CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                         else
                         {
-                            this.tx難易度とステージ数.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_X - this.tx難易度とステージ数.szテクスチャサイズ.Width, CDTXMania.Skin.Game_MusicName_Y);
+                            this.tx難易度とステージ数.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Game_MusicName_XY[0] - this.tx難易度とステージ数.szテクスチャサイズ.Width, CDTXMania.Skin.Game_MusicName_XY[1]);
                         }
                 }
 

--- a/DTXManiaプロジェクト/コード/ステージ/08.結果/CActResultSongBar.cs
+++ b/DTXManiaプロジェクト/コード/ステージ/08.結果/CActResultSongBar.cs
@@ -106,30 +106,30 @@ namespace DTXMania
 
             if (CDTXMania.Skin.Result_MusicName_ReferencePoint == CSkin.ReferencePoint.Center)
             {
-                this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_MusicName_X - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), CDTXMania.Skin.Result_MusicName_Y);
+                this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_MusicName_XY[0] - ((this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X) / 2), CDTXMania.Skin.Result_MusicName_XY[1]);
             }
             else if (CDTXMania.Skin.Result_MusicName_ReferencePoint == CSkin.ReferencePoint.Left)
             {
-                this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_MusicName_X, CDTXMania.Skin.Result_MusicName_Y);
+                this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_MusicName_XY[0], CDTXMania.Skin.Result_MusicName_XY[1]);
             }
             else
             {
-                this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_MusicName_X - this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X, CDTXMania.Skin.Result_MusicName_Y);
+                this.txMusicName.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_MusicName_XY[0] - this.txMusicName.szテクスチャサイズ.Width * txMusicName.vc拡大縮小倍率.X, CDTXMania.Skin.Result_MusicName_XY[1]);
             }
 
             if(CDTXMania.stage選曲.n確定された曲の難易度 != (int)Difficulty.Dan)
             {
                 if (CDTXMania.Skin.Result_StageText_ReferencePoint == CSkin.ReferencePoint.Center)
                 {
-                    this.txStageText.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_StageText_X - ((this.txStageText.szテクスチャサイズ.Width * txStageText.vc拡大縮小倍率.X) / 2), CDTXMania.Skin.Result_StageText_Y);
+                    this.txStageText.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_StageText_XY[0] - ((this.txStageText.szテクスチャサイズ.Width * txStageText.vc拡大縮小倍率.X) / 2), CDTXMania.Skin.Result_StageText_XY[1]);
                 }
                 else if (CDTXMania.Skin.Result_StageText_ReferencePoint == CSkin.ReferencePoint.Right)
                 {
-                    this.txStageText.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_StageText_X - this.txStageText.szテクスチャサイズ.Width, CDTXMania.Skin.Result_StageText_Y);
+                    this.txStageText.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_StageText_XY[0] - this.txStageText.szテクスチャサイズ.Width, CDTXMania.Skin.Result_StageText_XY[1]);
                 }
                 else
                 {
-                    this.txStageText.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_StageText_X, CDTXMania.Skin.Result_StageText_Y);
+                    this.txStageText.t2D描画(CDTXMania.app.Device, CDTXMania.Skin.Result_StageText_XY[0], CDTXMania.Skin.Result_StageText_XY[1]);
                 }
             }
 

--- a/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
+++ b/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
@@ -505,18 +505,35 @@ namespace DTXMania
                 Graphics gV = Graphics.FromImage(bmpV);
                 gV.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.HighQuality;
 
+                //SongSelect_Correction*_Charaの何番目に当該の文字があるかを取得(20181222 rhimm)
+                int IndexX = Array.IndexOf(CDTXMania.Skin.SongSelect_CorrectionX_Chara, strName[i]);
+                int IndexY = Array.IndexOf(CDTXMania.Skin.SongSelect_CorrectionY_Chara, strName[i]);
 
-                if (strName[i].In(CDTXMania.Skin.SongSelect_CorrectionX_Chara))
+                //取得した*_Charaの配列上の位置にある*_Chara_Valueの値で補正
+                //補正文字の数に比べて補正値の数が足りない時、配列の一番最後の補正値で足りない分の文字を補正
+                //例えば　補正文字あ,い,う,え,おに対して補正値が10,13,15の3つだった時、
+                //あ　は補正値10、い　は補正値13、　う,え,お　は補正値15　となるようにする(20181222 rhimm)
+
+                if (-1 < IndexX && IndexX < CDTXMania.Skin.SongSelect_CorrectionX_Chara_Value.Length && strName[i].In(CDTXMania.Skin.SongSelect_CorrectionX_Chara))
                 {
-                    nEdge補正X = CDTXMania.Skin.SongSelect_CorrectionX_Chara_Value;
+                    nEdge補正X = CDTXMania.Skin.SongSelect_CorrectionX_Chara_Value[IndexX];
+                }
+                else if(-1 < IndexX && CDTXMania.Skin.SongSelect_CorrectionX_Chara_Value.Length <= IndexX && strName[i].In(CDTXMania.Skin.SongSelect_CorrectionX_Chara))
+                {
+                    nEdge補正X = CDTXMania.Skin.SongSelect_CorrectionX_Chara_Value[CDTXMania.Skin.SongSelect_CorrectionX_Chara_Value.Length - 1];
                 }
                 else
                 {
                     nEdge補正X = 0;
                 }
-                if (strName[i].In(CDTXMania.Skin.SongSelect_CorrectionY_Chara))
+
+                if (-1 < IndexY && IndexY < CDTXMania.Skin.SongSelect_CorrectionY_Chara_Value.Length && strName[i].In(CDTXMania.Skin.SongSelect_CorrectionY_Chara))
                 {
-                    nEdge補正Y = CDTXMania.Skin.SongSelect_CorrectionY_Chara_Value;
+                    nEdge補正Y = CDTXMania.Skin.SongSelect_CorrectionY_Chara_Value[IndexY];
+                }
+                else if (-1 < IndexY && CDTXMania.Skin.SongSelect_CorrectionY_Chara_Value.Length <= IndexY && strName[i].In(CDTXMania.Skin.SongSelect_CorrectionY_Chara))
+                {
+                    nEdge補正Y = CDTXMania.Skin.SongSelect_CorrectionY_Chara_Value[CDTXMania.Skin.SongSelect_CorrectionY_Chara_Value.Length - 1];
                 }
                 else
                 {

--- a/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
+++ b/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
@@ -332,7 +332,7 @@ namespace DTXMania
             sf.FormatFlags = StringFormatFlags.NoWrap; // どんなに長くて単語の区切りが良くても改行しない (AioiLight)
             sf.Trimming = StringTrimming.None; // どんなに長くてもトリミングしない (AioiLight)
 			// レイアウト枠
-			Rectangle r = new Rectangle( 0, 0, stringSize.Width + nEdgePt * 2 + (CDTXMania.Skin.Text_Correction_X * stringSize.Width / 100), stringSize.Height + nEdgePt * 2 + (CDTXMania.Skin.Text_Correction_Y * stringSize.Height / 100));
+			Rectangle r = new Rectangle( 0, 0, stringSize.Width + nEdgePt * 2 + (CDTXMania.Skin.Text_Correction_XY[0] * stringSize.Width / 100), stringSize.Height + nEdgePt * 2 + (CDTXMania.Skin.Text_Correction_XY[1] * stringSize.Height / 100));
 
 			if ( bEdge )	// 縁取り有りの描画
 			{

--- a/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
+++ b/DTXManiaプロジェクト/コード/全体/CPrivateFont.cs
@@ -8,6 +8,7 @@ using System.Drawing.Drawing2D;
 using System.Diagnostics;
 using SlimDX;
 using FDK;
+using FDK.ExtensionMethods;
 using System.Linq;
 
 namespace DTXMania
@@ -39,15 +40,6 @@ namespace DTXMania
     /// テクスチャに定義するようにしてください。
     /// </remarks>
 
-    #region In拡張子
-    public static class StringExtensions
-    {
-        public static bool In(this string str, params string[] param)
-        {
-            return param.Contains(str);
-        }
-    }
-    #endregion
 
     public class CPrivateFont : IDisposable
 	{

--- a/DTXManiaプロジェクト/コード/全体/CSkin.cs
+++ b/DTXManiaプロジェクト/コード/全体/CSkin.cs
@@ -977,13 +977,9 @@ namespace DTXMania
 
                             #region 新・SkinConfig
                             #region Config
-                            else if (strCommand == nameof(Config_ItemText_Correction_X))
+                            else if (strCommand == nameof(Config_ItemText_Correction_XY))
                             {
-                                Config_ItemText_Correction_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(Config_ItemText_Correction_Y))
-                            {
-                                Config_ItemText_Correction_Y = int.Parse(strParam);
+                                Config_ItemText_Correction_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             #endregion
                             #region SongSelect
@@ -1112,29 +1108,17 @@ namespace DTXMania
                             }
                             #endregion
                             #region SongLoading
-                            else if (strCommand == nameof(SongLoading_Plate_X))
+                            else if (strCommand == nameof(SongLoading_Plate_XY))
                             {
-                                SongLoading_Plate_X = int.Parse(strParam);
+                                SongLoading_Plate_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
-                            else if (strCommand == nameof(SongLoading_Plate_Y))
+                            else if (strCommand == nameof(SongLoading_Title_XY))
                             {
-                                SongLoading_Plate_Y = int.Parse(strParam);
+                                SongLoading_Title_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
-                            else if (strCommand == nameof(SongLoading_Title_X))
+                            else if (strCommand == nameof(SongLoading_SubTitle_XY))
                             {
-                                SongLoading_Title_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(SongLoading_Title_Y))
-                            {
-                                SongLoading_Title_Y = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(SongLoading_SubTitle_X))
-                            {
-                                SongLoading_SubTitle_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(SongLoading_SubTitle_Y))
-                            {
-                                SongLoading_SubTitle_Y = int.Parse(strParam);
+                                SongLoading_SubTitle_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             else if (strCommand == nameof(SongLoading_Title_FontSize))
                             {
@@ -1217,13 +1201,9 @@ namespace DTXMania
                             }
                             #endregion
                             #region PanelFont
-                            else if (strCommand == nameof(Game_MusicName_X))
+                            else if (strCommand == nameof(Game_MusicName_XY))
                             {
-                                Game_MusicName_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(Game_MusicName_Y))
-                            {
-                                Game_MusicName_Y = int.Parse(strParam);
+                                Game_MusicName_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             else if (strCommand == nameof(Game_MusicName_FontSize))
                             {
@@ -1234,21 +1214,13 @@ namespace DTXMania
                             {
                                 Game_MusicName_ReferencePoint = (ReferencePoint)int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(Game_Genre_X))
+                            else if (strCommand == nameof(Game_Genre_XY))
                             {
-                                Game_Genre_X = int.Parse(strParam);
+                                Game_Genre_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
-                            else if (strCommand == nameof(Game_Genre_Y))
+                            else if (strCommand == nameof(Game_Lyric_XY))
                             {
-                                Game_Genre_Y = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(Game_Lyric_X))
-                            {
-                                Game_Lyric_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(Game_Lyric_Y))
-                            {
-                                Game_Lyric_Y = int.Parse(strParam);
+                                Game_Lyric_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             else if (strCommand == nameof(Game_Lyric_FontName))
                             {
@@ -2126,13 +2098,9 @@ namespace DTXMania
                             #endregion
                             #endregion
                             #region Result
-                            else if (strCommand == nameof(Result_MusicName_X))
+                            else if (strCommand == nameof(Result_MusicName_XY))
                             {
-                                Result_MusicName_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(Result_MusicName_Y))
-                            {
-                                Result_MusicName_Y = int.Parse(strParam);
+                                Result_MusicName_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             else if (strCommand == nameof(Result_MusicName_FontSize))
                             {
@@ -2143,13 +2111,9 @@ namespace DTXMania
                             {
                                 Result_MusicName_ReferencePoint = (ReferencePoint)int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(Result_StageText_X))
+                            else if (strCommand == nameof(Result_StageText_XY))
                             {
-                                Result_StageText_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(Result_StageText_Y))
-                            {
-                                Result_StageText_Y = int.Parse(strParam);
+                                Result_StageText_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             else if (strCommand == nameof(Result_StageText_FontSize))
                             {
@@ -2224,13 +2188,9 @@ namespace DTXMania
                                 if (int.Parse(strParam) > 0)
                                     Font_Edge_Ratio_Vertical = int.Parse(strParam);
                             }
-                            else if (strCommand == nameof(Text_Correction_X))
+                            else if (strCommand == nameof(Text_Correction_XY))
                             {
-                                Text_Correction_X = int.Parse(strParam);
-                            }
-                            else if (strCommand == nameof(Text_Correction_Y))
-                            {
-                                Text_Correction_Y = int.Parse(strParam);
+                                Text_Correction_XY = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             #endregion
                             #endregion
@@ -2389,8 +2349,7 @@ namespace DTXMania
         public string Skin_Creator = "Unknown";
         #endregion
         #region Config
-        public int Config_ItemText_Correction_X = 0;
-        public int Config_ItemText_Correction_Y = 0;
+        public int[] Config_ItemText_Correction_XY = new int[] { 0, 0 };
         #endregion
         #region SongSelect
         public int SongSelect_Overall_Y = 123;
@@ -2418,15 +2377,12 @@ namespace DTXMania
         public string[] SongSelect_CorrectionY_Chara = { "ここにY座標を補正したい文字をカンマで区切って記入" };
         public int SongSelect_CorrectionX_Chara_Value = 0;
         public int SongSelect_CorrectionY_Chara_Value = 0;
-        public string[] SongSelect_Rotate_Chara = { "ここに90℃回転させたい文字をカンマで区切って記入" };
+        public string[] SongSelect_Rotate_Chara = { "ここに90°回転させたい文字をカンマで区切って記入" };
         #endregion
         #region SongLoading
-        public int SongLoading_Plate_X = 640;
-        public int SongLoading_Plate_Y = 360;
-        public int SongLoading_Title_X = 640;
-        public int SongLoading_Title_Y = 340;
-        public int SongLoading_SubTitle_X = 640;
-        public int SongLoading_SubTitle_Y = 390;
+        public int[] SongLoading_Plate_XY = new int[] { 640, 360 };
+        public int[] SongLoading_Title_XY = new int[] { 640, 340 };
+        public int[] SongLoading_SubTitle_XY = new int[] { 640, 390 };
         public int SongLoading_Title_FontSize = 30;
         public int SongLoading_SubTitle_FontSize = 22;
         public ReferencePoint SongLoading_Plate_ReferencePoint = ReferencePoint.Center;
@@ -2488,14 +2444,11 @@ namespace DTXMania
         public int[] Game_CourseSymbol_Y = new int[] { 232, 432 };
         #endregion
         #region PanelFont
-        public int Game_MusicName_X = 1254;
-        public int Game_MusicName_Y = 14;
+        public int[] Game_MusicName_XY = new int[] { 1254, 14 };
+        public int[] Game_Genre_XY = new int[] { 1114, 74 };
+        public int[] Game_Lyric_XY = new int[] { 640, 630 };
         public int Game_MusicName_FontSize = 30;
         public ReferencePoint Game_MusicName_ReferencePoint = ReferencePoint.Right;
-        public int Game_Genre_X = 1114;
-        public int Game_Genre_Y = 74;
-        public int Game_Lyric_X = 640;
-        public int Game_Lyric_Y = 630;
         public string Game_Lyric_FontName = "MS UI Gothic";
         public int Game_Lyric_FontSize = 38;
         public ReferencePoint Game_Lyric_ReferencePoint = ReferencePoint.Center;
@@ -2652,12 +2605,10 @@ namespace DTXMania
         #endregion
         #endregion
         #region Result
-        public int Result_MusicName_X = 1254;
-        public int Result_MusicName_Y = 6;
+        public int[] Result_MusicName_XY = new int[] { 1254, 6 };
         public int Result_MusicName_FontSize = 30;
         public ReferencePoint Result_MusicName_ReferencePoint = ReferencePoint.Right;
-        public int Result_StageText_X = 230;
-        public int Result_StageText_Y = 6;
+        public int[] Result_StageText_XY = new int[] { 230, 6 };
         public int Result_StageText_FontSize = 30;
         public ReferencePoint Result_StageText_ReferencePoint = ReferencePoint.Left;
 
@@ -2677,8 +2628,7 @@ namespace DTXMania
         #region Font
         public int Font_Edge_Ratio = 30;
         public int Font_Edge_Ratio_Vertical = 30;
-        public int Text_Correction_X = 0;
-        public int Text_Correction_Y = 0;
+        public int[] Text_Correction_XY = new int[] { 0, 0 };
         #endregion
         #endregion
     }

--- a/DTXManiaプロジェクト/コード/全体/CSkin.cs
+++ b/DTXManiaプロジェクト/コード/全体/CSkin.cs
@@ -1096,11 +1096,11 @@ namespace DTXMania
                             }
                             else if (strCommand == nameof(SongSelect_CorrectionX_Chara_Value))
                             {
-                                SongSelect_CorrectionX_Chara_Value = int.Parse(strParam);
+                                SongSelect_CorrectionX_Chara_Value = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             else if (strCommand == nameof(SongSelect_CorrectionY_Chara_Value))
                             {
-                                SongSelect_CorrectionY_Chara_Value = int.Parse(strParam);
+                                SongSelect_CorrectionY_Chara_Value = strParam.Split(',').Select(int.Parse).ToArray();
                             }
                             else if (strCommand == nameof(SongSelect_Rotate_Chara))
                             {
@@ -2375,8 +2375,8 @@ namespace DTXMania
         public Color SongSelect_BackColor_Namco = ColorTranslator.FromHtml("#980E00");
         public string[] SongSelect_CorrectionX_Chara = { "ここにX座標を補正したい文字をカンマで区切って記入" };
         public string[] SongSelect_CorrectionY_Chara = { "ここにY座標を補正したい文字をカンマで区切って記入" };
-        public int SongSelect_CorrectionX_Chara_Value = 0;
-        public int SongSelect_CorrectionY_Chara_Value = 0;
+        public int[] SongSelect_CorrectionX_Chara_Value = new int[] { 0 };
+        public int[] SongSelect_CorrectionY_Chara_Value = new int[] { 0 };
         public string[] SongSelect_Rotate_Chara = { "ここに90°回転させたい文字をカンマで区切って記入" };
         #endregion
         #region SongLoading

--- a/FDK17プロジェクト/コード/00.共通/ExtensionMethods/StringExtensions.cs
+++ b/FDK17プロジェクト/コード/00.共通/ExtensionMethods/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace FDK.ExtensionMethods
+{
+    public static class StringExtensions
+    {
+        public static bool In(this string str, params string[] param)
+        {
+            return param.Contains(str);
+        }
+    }
+}


### PR DESCRIPTION
以下の変更を含みます。
・*_X,*_Y　という名前の設定項目のうち、値をそれぞれ一つしか取らないものを *_XY という項目にまとめた
→SkinConfigスプレッドシートの容量削減のためです

・In拡張子を用いるためにCPrivateFontに置いていた静的クラスを移動
→素人目ですが、「選曲画面→設定画面→選曲画面→・・・」の往復を繰り返した時、タスクマネージャで確認できるメモリ使用量が少しだけ減ったような気がします。無意味だったらすみません。

・SongSelect_Correction*_Chara_Valueの値を複数取れるようにした

＜用例1＞
SongSelect_CorrectionX_Chara=あ,い,う,え,お,か,き,く,け,こ
SongSelect_CorrectionX_Chara_Value=1,2,4,5,7,9,10,11,12,3
→SongSelect_CorrectionX_Charaのn番目の文字は、SongSelect_CorrectionX_Chara_Valueのn番目の補正値が当てられる

＜用例2＞
SongSelect_CorrectionY_Chara=A,B,C,D,E,F,G,H,I,J
SongSelect_CorrectionX_Chara_Value=1,5,10
→SongSelect_CorrectionY_Charaのn番目の文字は、SongSelect_CorrectionY_Chara_Valueのn番目の補正値が当てられるが、n番目の補正値がない時、最後に書かれた補正値で全ての文字を補正する（この例の時、C,D,E,F,G,H,I,Jは全て補正値10が当てられる）

用法がメチャクチャややこしいですが、以前のような一括補正と両立させたかったため、こういう形になりました。