### PR TITLE
RandomとBackBoxのGenreBackを前選択ジャンルにする

### DIFF
--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -297,7 +297,7 @@ namespace TJAPlayer3
 
                 if( this.r現在選択中の曲 != null )
                 {
-                    if(this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル) != 0 || r現在選択中の曲.eノード種別 == C曲リストノード.Eノード種別.BOX)
+                    if(this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル) != 0 || r現在選択中の曲.eノード種別 == C曲リストノード.Eノード種別.BOX || r現在選択中の曲.eノード種別 == C曲リストノード.Eノード種別.SCORE)
                     {
                         nGenreBack = this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル);
                     }

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -297,11 +297,15 @@ namespace TJAPlayer3
 
                 if( this.r現在選択中の曲 != null )
                 {
-                    if (TJAPlayer3.Tx.SongSelect_GenreBack[ this.nStrジャンルtoNum( this.r現在選択中の曲.strジャンル ) ] != null )
+                    if(this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル) != 0 || r現在選択中の曲.eノード種別 == C曲リストノード.Eノード種別.BOX)
+                    {
+                        nGenreBack = this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル);
+                    }
+                    if (TJAPlayer3.Tx.SongSelect_GenreBack[nGenreBack] != null )
                     {
                         for( int i = 0 ; i <(1280 / TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width) + 2; i++ )
-                            if (TJAPlayer3.Tx.SongSelect_GenreBack[ this.nStrジャンルtoNum( this.r現在選択中の曲.strジャンル ) ] != null )
-                                    TJAPlayer3.Tx.SongSelect_GenreBack[this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル)].t2D描画(TJAPlayer3.app.Device, -ct背景スクロール用タイマー.n現在の値 + TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width * i , 0);
+                            if (TJAPlayer3.Tx.SongSelect_GenreBack[nGenreBack] != null )
+                                    TJAPlayer3.Tx.SongSelect_GenreBack[nGenreBack].t2D描画(TJAPlayer3.app.Device, -ct背景スクロール用タイマー.n現在の値 + TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width * i , 0);
                     }
                 }
 
@@ -752,6 +756,7 @@ namespace TJAPlayer3
 		public CActSortSongs actSortSongs;
 		private CActSelectQuickConfig actQuickConfig;
 
+                private int nGenreBack;
 		private bool bBGM再生済み;
 		private STキー反復用カウンタ ctキー反復用;
 		public CCounter ct登場時アニメ用共通;


### PR DESCRIPTION
RandomとBackBoxのGenreBackを前選択ジャンルにしました。
説明：
nGenreBackという変数を作成。
名前の通りGenreBackのジャンル番号を格納しています。
ジャンルなし(nGenre=0)でRandomまたはBackBoxのときに値を更新しないことで、
BOX内のランダム、閉じる。BOX外のランダムで、背景が変わらず見栄えをよくできます。
BOXとSCOREに割り当てられたGenre=0は、対象外です。

例：
J-POPの後にランダム選曲を選択→J-POPの背景
アニメの後にランダム選曲を選択→アニメの背景