### PR TITLE
Deduplicate code that uses genre strings to index into other structures

### DIFF
--- a/TJAPlayer3.Tests/Songs/CStrジャンルtoNumTests.cs
+++ b/TJAPlayer3.Tests/Songs/CStrジャンルtoNumTests.cs
@@ -1,0 +1,152 @@
+﻿using NUnit.Framework;
+
+namespace TJAPlayer3.Tests.Songs
+{
+    [TestFixture]
+    public sealed class CStrジャンルtoNumTests
+    {
+        [Test]
+        [TestCase("アニメ", 0)]
+        [TestCase("J-POP", 1)]
+        [TestCase("ゲームミュージック", 2)]
+        [TestCase("ナムコオリジナル", 3)]
+        [TestCase("クラシック", 4)]
+        [TestCase("どうよう", 5)]
+        [TestCase("バラエティ", 6)]
+        [TestCase("ボーカロイド", 7)]
+        [TestCase("VOCALOID", 7)]
+        [TestCase(null, 8)]
+        [TestCase("", 8)]
+        [TestCase(" ", 8)]
+        [TestCase("unknown value", 8)]
+        [TestCase(" アニメ", 8)]
+        [TestCase(" アニメ ", 8)]
+        [TestCase("アニメ ", 8)]
+        public void TestForAC8_14SortOrder(string strジャンル, int expected)
+        {
+            var actual = CStrジャンルtoNum.ForAC8_14SortOrder(strジャンル);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase("J-POP", 0)]
+        [TestCase("アニメ", 1)]
+        [TestCase("ボーカロイド", 2)]
+        [TestCase("VOCALOID", 2)]
+        [TestCase("どうよう", 3)]
+        [TestCase("バラエティ", 4)]
+        [TestCase("クラシック", 5)]
+        [TestCase("ゲームミュージック", 6)]
+        [TestCase("ナムコオリジナル", 7)]
+        [TestCase(null, 8)]
+        [TestCase("", 8)]
+        [TestCase(" ", 8)]
+        [TestCase("unknown value", 8)]
+        [TestCase(" アニメ", 8)]
+        [TestCase(" アニメ ", 8)]
+        [TestCase("アニメ ", 8)]
+        public void TestForAC15SortOrder(string strジャンル, int expected)
+        {
+            var actual = CStrジャンルtoNum.ForAC15SortOrder(strジャンル);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase(null, 0)]
+        [TestCase("", 0)]
+        [TestCase(" ", 0)]
+        [TestCase("unknown value", 0)]
+        [TestCase(" アニメ", 0)]
+        [TestCase(" アニメ ", 0)]
+        [TestCase("アニメ ", 0)]
+        [TestCase("J-POP", 1)]
+        [TestCase("アニメ", 2)]
+        [TestCase("ゲームミュージック", 3)]
+        [TestCase("ナムコオリジナル", 4)]
+        [TestCase("クラシック", 5)]
+        [TestCase("バラエティ", 6)]
+        [TestCase("どうよう", 7)]
+        [TestCase("ボーカロイド", 8)]
+        [TestCase("VOCALOID", 8)]
+        public void TestForBarGenreIndex(string strジャンル, int expected)
+        {
+            var actual = CStrジャンルtoNum.ForBarGenreIndex(strジャンル);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase(null, 0)]
+        [TestCase("", 0)]
+        [TestCase(" ", 0)]
+        [TestCase("unknown value", 0)]
+        [TestCase(" アニメ", 0)]
+        [TestCase(" アニメ ", 0)]
+        [TestCase("アニメ ", 0)]
+        [TestCase("J-POP", 1)]
+        [TestCase("アニメ", 2)]
+        [TestCase("ゲームミュージック", 3)]
+        [TestCase("ナムコオリジナル", 4)]
+        [TestCase("クラシック", 5)]
+        [TestCase("バラエティ", 6)]
+        [TestCase("どうよう", 7)]
+        [TestCase("ボーカロイド", 8)]
+        [TestCase("VOCALOID", 8)]
+        public void TestForFrameBoxIndex(string strジャンル, int expected)
+        {
+            var actual = CStrジャンルtoNum.ForFrameBoxIndex(strジャンル);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase(null, 0)]
+        [TestCase("", 0)]
+        [TestCase(" ", 0)]
+        [TestCase("unknown value", 0)]
+        [TestCase(" アニメ", 0)]
+        [TestCase(" アニメ ", 0)]
+        [TestCase("アニメ ", 0)]
+        [TestCase("J-POP", 1)]
+        [TestCase("アニメ", 2)]
+        [TestCase("ゲームミュージック", 3)]
+        [TestCase("ナムコオリジナル", 4)]
+        [TestCase("クラシック", 5)]
+        [TestCase("バラエティ", 6)]
+        [TestCase("どうよう", 7)]
+        [TestCase("ボーカロイド", 8)]
+        [TestCase("VOCALOID", 8)]
+        public void TestForGenreBackIndex(string strジャンル, int expected)
+        {
+            var actual = CStrジャンルtoNum.ForGenreBackIndex(strジャンル);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase("アニメ", 0)]
+        [TestCase("J-POP", 1)]
+        [TestCase("ゲームミュージック", 2)]
+        [TestCase("ナムコオリジナル", 3)]
+        [TestCase("クラシック", 4)]
+        [TestCase("どうよう", 5)]
+        [TestCase("バラエティ", 6)]
+        [TestCase("ボーカロイド", 7)]
+        [TestCase("VOCALOID", 7)]
+        [TestCase(null, 8)]
+        [TestCase("", 8)]
+        [TestCase(" ", 8)]
+        [TestCase("unknown value", 8)]
+        [TestCase(" アニメ", 8)]
+        [TestCase(" アニメ ", 8)]
+        [TestCase("アニメ ", 8)]
+        public void TestForGenreTextIndex(string strジャンル, int expected)
+        {
+            var actual = CStrジャンルtoNum.ForGenreTextIndex(strジャンル);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+}

--- a/TJAPlayer3.Tests/Songs/CStrジャンルtoNumTests.cs
+++ b/TJAPlayer3.Tests/Songs/CStrジャンルtoNumTests.cs
@@ -30,23 +30,23 @@ namespace TJAPlayer3.Tests.Songs
         }
 
         [Test]
-        [TestCase("J-POP", 0)]
-        [TestCase("アニメ", 1)]
-        [TestCase("ボーカロイド", 2)]
-        [TestCase("VOCALOID", 2)]
-        [TestCase("どうよう", 3)]
-        [TestCase("バラエティ", 4)]
-        [TestCase("クラシック", 5)]
-        [TestCase("ゲームミュージック", 6)]
-        [TestCase("ナムコオリジナル", 7)]
-        [TestCase(null, 8)]
-        [TestCase("", 8)]
-        [TestCase(" ", 8)]
-        [TestCase("unknown value", 8)]
-        [TestCase(" アニメ", 8)]
-        [TestCase(" アニメ ", 8)]
-        [TestCase("アニメ ", 8)]
-        public void TestForAC15SortOrder(string strジャンル, int expected)
+        [TestCase("J-POP", EジャンルAC15SortOrder.JPOP)]
+        [TestCase("アニメ", EジャンルAC15SortOrder.アニメ)]
+        [TestCase("ボーカロイド", EジャンルAC15SortOrder.ボーカロイド)]
+        [TestCase("VOCALOID", EジャンルAC15SortOrder.ボーカロイド)]
+        [TestCase("どうよう", EジャンルAC15SortOrder.どうよう)]
+        [TestCase("バラエティ", EジャンルAC15SortOrder.バラエティ)]
+        [TestCase("クラシック", EジャンルAC15SortOrder.クラシック)]
+        [TestCase("ゲームミュージック", EジャンルAC15SortOrder.ゲームミュージック)]
+        [TestCase("ナムコオリジナル", EジャンルAC15SortOrder.ナムコオリジナル)]
+        [TestCase(null, EジャンルAC15SortOrder.Unknown)]
+        [TestCase("", EジャンルAC15SortOrder.Unknown)]
+        [TestCase(" ", EジャンルAC15SortOrder.Unknown)]
+        [TestCase("unknown value", EジャンルAC15SortOrder.Unknown)]
+        [TestCase(" アニメ", EジャンルAC15SortOrder.Unknown)]
+        [TestCase(" アニメ ", EジャンルAC15SortOrder.Unknown)]
+        [TestCase("アニメ ", EジャンルAC15SortOrder.Unknown)]
+        public void TestForAC15SortOrder(string strジャンル, EジャンルAC15SortOrder expected)
         {
             var actual = CStrジャンルtoNum.ForAC15SortOrder(strジャンル);
 

--- a/TJAPlayer3.Tests/Songs/CStrジャンルtoStrTests.cs
+++ b/TJAPlayer3.Tests/Songs/CStrジャンルtoStrTests.cs
@@ -1,0 +1,32 @@
+﻿using NUnit.Framework;
+
+namespace TJAPlayer3.Tests.Songs
+{
+    [TestFixture]
+    public sealed class CStrジャンルtoStrTests
+    {
+        [Test]
+        [TestCase("アニメ", "Anime")]
+        [TestCase("J-POP", "J-POP")]
+        [TestCase("ゲームミュージック", "Game")]
+        [TestCase("ナムコオリジナル", "Namco")]
+        [TestCase("クラシック", "Classic")]
+        [TestCase("どうよう", "Child")]
+        [TestCase("バラエティ", "Variety")]
+        [TestCase("ボーカロイド", "Vocaloid")]
+        [TestCase("VOCALOID", "Vocaloid")]
+        [TestCase(null, null)]
+        [TestCase("", null)]
+        [TestCase(" ", null)]
+        [TestCase("unknown value", null)]
+        [TestCase(" アニメ", null)]
+        [TestCase(" アニメ ", null)]
+        [TestCase("アニメ ", null)]
+        public void TestForTextureFileName(string strジャンル, string expected)
+        {
+            var actual = CStrジャンルtoStr.ForTextureFileName(strジャンル);
+
+            Assert.That(actual, Is.EqualTo(expected));
+        }
+    }
+}

--- a/TJAPlayer3.Tests/TJAPlayer3.Tests.csproj
+++ b/TJAPlayer3.Tests/TJAPlayer3.Tests.csproj
@@ -49,6 +49,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Songs\CStrジャンルtoNumTests.cs" />
+    <Compile Include="Songs\CStrジャンルtoStrTests.cs" />
     <Compile Include="コード\スコア、曲\CDTXStyleExtractorTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/TJAPlayer3/Common/C定数.cs
+++ b/TJAPlayer3/Common/C定数.cs
@@ -27,18 +27,7 @@ namespace TJAPlayer3
         BMSCROLL,
         HBSCROLL
     }
-    public enum Eジャンル
-    {
-        None = 0,
-        JPOP = 1,
-        ゲーム = 2,
-        ナムコ = 3,
-        クラシック = 4,
-        バラエティ = 5,
-        どうよう = 6,
-        ボーカロイド = 7,
-        アニメ = 8
-    }
+
     public enum EGame
     {
         OFF = 0,

--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -1129,7 +1129,6 @@ namespace TJAPlayer3
         public double db再生速度;
         public E種別 e種別;
         public string GENRE;
-        public Eジャンル eジャンル;
         public bool HIDDENLEVEL;
         public STDGBVALUE<int> LEVEL;
         public int[] LEVELtaiko = new int[(int)Difficulty.Total] { -1, -1, -1, -1, -1, -1, -1 };
@@ -1301,7 +1300,6 @@ namespace TJAPlayer3
             this.COMMENT = "";
             this.PANEL = "";
             this.GENRE = "";
-            this.eジャンル = Eジャンル.None;
             this.PREVIEW = "";
             this.PREIMAGE = "";
             this.BACKGROUND = "";

--- a/TJAPlayer3/Songs/CSong管理.cs
+++ b/TJAPlayer3/Songs/CSong管理.cs
@@ -306,37 +306,37 @@ namespace TJAPlayer3
                                 }
 
 
-                                switch (CStrジャンルtoNum.ForAC15SortOrder(c曲リストノード.strジャンル)) // twopointzero parse to enum!
+                                switch (CStrジャンルtoNum.ForAC15SortOrder(c曲リストノード.strジャンル))
                                 {
-                                    case 0:
+                                    case EジャンルAC15SortOrder.JPOP:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_JPOP;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_JPOP;
                                         break;
-                                    case 1:
+                                    case EジャンルAC15SortOrder.アニメ:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Anime;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Anime;
                                         break;
-                                    case 2:
+                                    case EジャンルAC15SortOrder.ボーカロイド:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_VOCALOID;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_VOCALOID;
                                         break;
-                                    case 3:
+                                    case EジャンルAC15SortOrder.どうよう:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Children;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Children;
                                         break;
-                                    case 4:
+                                    case EジャンルAC15SortOrder.バラエティ:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Variety;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Variety;
                                         break;
-                                    case 5:
+                                    case EジャンルAC15SortOrder.クラシック:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Classic;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Classic;
                                         break;
-                                    case 6:
+                                    case EジャンルAC15SortOrder.ゲームミュージック:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_GameMusic;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_GameMusic;
                                         break;
-                                    case 7:
+                                    case EジャンルAC15SortOrder.ナムコオリジナル:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Namco;
                                         c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Namco;
                                         break;
@@ -510,37 +510,37 @@ namespace TJAPlayer3
                         c曲リストノード.IsChangedBackColor = true;
                     }
 
-                    switch (CStrジャンルtoNum.ForAC15SortOrder(c曲リストノード.strジャンル)) // twopointzero parse to enum!
+                    switch (CStrジャンルtoNum.ForAC15SortOrder(c曲リストノード.strジャンル))
                     {
-                        case 0:
+                        case EジャンルAC15SortOrder.JPOP:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_JPOP;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_JPOP;
                             break;
-                        case 1:
+                        case EジャンルAC15SortOrder.アニメ:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Anime;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Anime;
                             break;
-                        case 2:
+                        case EジャンルAC15SortOrder.ボーカロイド:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_VOCALOID;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_VOCALOID;
                             break;
-                        case 3:
+                        case EジャンルAC15SortOrder.どうよう:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Children;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Children;
                             break;
-                        case 4:
+                        case EジャンルAC15SortOrder.バラエティ:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Variety;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Variety;
                             break;
-                        case 5:
+                        case EジャンルAC15SortOrder.クラシック:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Classic;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Classic;
                             break;
-                        case 6:
+                        case EジャンルAC15SortOrder.ゲームミュージック:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_GameMusic;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_GameMusic;
                             break;
-                        case 7:
+                        case EジャンルAC15SortOrder.ナムコオリジナル:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_Namco;
                             c曲リストノード.BackColor = TJAPlayer3.Skin.SongSelect_BackColor_Namco;
                             break;

--- a/TJAPlayer3/Songs/CSong管理.cs
+++ b/TJAPlayer3/Songs/CSong管理.cs
@@ -306,7 +306,7 @@ namespace TJAPlayer3
                                 }
 
 
-                                switch (CStrジャンルtoNum.ForAC15(c曲リストノード.strジャンル))
+                                switch (CStrジャンルtoNum.ForAC15SortOrder(c曲リストノード.strジャンル)) // twopointzero parse to enum!
                                 {
                                     case 0:
                                         c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_JPOP;
@@ -510,7 +510,7 @@ namespace TJAPlayer3
                         c曲リストノード.IsChangedBackColor = true;
                     }
 
-                    switch (CStrジャンルtoNum.ForAC15(c曲リストノード.strジャンル))
+                    switch (CStrジャンルtoNum.ForAC15SortOrder(c曲リストノード.strジャンル)) // twopointzero parse to enum!
                     {
                         case 0:
                             c曲リストノード.ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor_JPOP;

--- a/TJAPlayer3/Songs/CStrジャンル.cs
+++ b/TJAPlayer3/Songs/CStrジャンル.cs
@@ -1,0 +1,15 @@
+﻿namespace TJAPlayer3
+{
+    internal static class CStrジャンル
+    {
+        public const string アニメ = "アニメ";
+        public const string JPOP = "J-POP";
+        public const string ゲームミュージック = "ゲームミュージック";
+        public const string ナムコオリジナル = "ナムコオリジナル";
+        public const string クラシック = "クラシック";
+        public const string どうよう = "どうよう";
+        public const string バラエティ = "バラエティ";
+        public const string ボーカロイドJP = "ボーカロイド";
+        public const string ボーカロイドEN = "VOCALOID";
+    }
+}

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -54,6 +54,32 @@
             }
         }
 
+        internal static int ForFrameBoxIndex( string strジャンル )
+        {
+            switch ( strジャンル )
+            {
+                case "J-POP":
+                    return 1;
+                case "アニメ":
+                    return 2;
+                case "ゲームミュージック":
+                    return 3;
+                case "ナムコオリジナル":
+                    return 4;
+                case "クラシック":
+                    return 5;
+                case "バラエティ":
+                    return 6;
+                case "どうよう":
+                    return 7;
+                case "ボーカロイド":
+                case "VOCALOID":
+                    return 8;
+                default:
+                    return 0;
+            }
+        }
+
         internal static int ForGenreBackIndex( string strジャンル )
         {
             switch( strジャンル )

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -56,28 +56,7 @@
 
         internal static int ForBarGenreIndex( string strジャンル )
         {
-            switch ( strジャンル )
-            {
-                case "J-POP":
-                    return 1;
-                case "アニメ":
-                    return 2;
-                case "ゲームミュージック":
-                    return 3;
-                case "ナムコオリジナル":
-                    return 4;
-                case "クラシック":
-                    return 5;
-                case "バラエティ":
-                    return 6;
-                case "どうよう":
-                    return 7;
-                case "ボーカロイド":
-                case "VOCALOID":
-                    return 8;
-                default:
-                    return 0;
-            }
+            return ForGenreBackIndex( strジャンル );
         }
 
         internal static int ForFrameBoxIndex( string strジャンル )

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -58,20 +58,20 @@
         {
             switch( strジャンル )
             {
-                case "アニメ":
-                    return 2;
                 case "J-POP":
                     return 1;
+                case "アニメ":
+                    return 2;
                 case "ゲームミュージック":
                     return 3;
                 case "ナムコオリジナル":
                     return 4;
                 case "クラシック":
                     return 5;
-                case "どうよう":
-                    return 7;
                 case "バラエティ":
                     return 6;
+                case "どうよう":
+                    return 7;
                 case "ボーカロイド":
                 case "VOCALOID":
                     return 8;

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -94,5 +94,31 @@
         {
             return ForAC8_14SortOrder( strジャンル );
         }
+        
+        internal static string ForTextureFileName( string genreName )
+        {
+            switch (genreName)
+            {
+                case "アニメ":
+                    return "Anime";
+                case "J-POP":
+                    return "J-POP";
+                case "ゲームミュージック":
+                    return "Game";
+                case "ナムコオリジナル":
+                    return "Namco";
+                case "クラシック":
+                    return "Classic";
+                case "どうよう":
+                    return "Child";
+                case "バラエティ":
+                    return "Variety";
+                case "ボーカロイド":
+                case "VOCALOID":
+                    return "Vocaloid";
+                default:
+                    return null;
+            }
+        }
     }
 }

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -2,7 +2,7 @@
 {
     internal static class CStrジャンルtoNum
     {
-        internal static int ForAC8_14( string strジャンル )
+        internal static int ForAC8_14SortOrder( string strジャンル )
         {
             switch( strジャンル )
             {
@@ -28,7 +28,7 @@
             }
         }
 
-        internal static int ForAC15(string strジャンル)
+        internal static int ForAC15SortOrder(string strジャンル)
         {
             switch (strジャンル)
             {

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -6,22 +6,22 @@
         {
             switch( strジャンル )
             {
-                case "アニメ":
+                case CStrジャンル.アニメ:
                     return 0;
-                case "J-POP":
+                case CStrジャンル.JPOP:
                     return 1;
-                case "ゲームミュージック":
+                case CStrジャンル.ゲームミュージック:
                     return 2;
-                case "ナムコオリジナル":
+                case CStrジャンル.ナムコオリジナル:
                     return 3;
-                case "クラシック":
+                case CStrジャンル.クラシック:
                     return 4;
-                case "どうよう":
+                case CStrジャンル.どうよう:
                     return 5;
-                case "バラエティ":
+                case CStrジャンル.バラエティ:
                     return 6;
-                case "ボーカロイド":
-                case "VOCALOID":
+                case CStrジャンル.ボーカロイドJP:
+                case CStrジャンル.ボーカロイドEN:
                     return 7;
                 default:
                     return 8;
@@ -30,24 +30,24 @@
 
         internal static int ForAC15SortOrder( string strジャンル )
         {
-            switch (strジャンル)
+            switch ( strジャンル )
             {
-                case "J-POP":
+                case CStrジャンル.JPOP:
                     return 0;
-                case "アニメ":
+                case CStrジャンル.アニメ:
                     return 1;
-                case "ボーカロイド":
-                case "VOCALOID":
+                case CStrジャンル.ボーカロイドJP:
+                case CStrジャンル.ボーカロイドEN:
                     return 2;
-                case "どうよう":
+                case CStrジャンル.どうよう:
                     return 3;
-                case "バラエティ":
+                case CStrジャンル.バラエティ:
                     return 4;
-                case "クラシック":
+                case CStrジャンル.クラシック:
                     return 5;
-                case "ゲームミュージック":
+                case CStrジャンル.ゲームミュージック:
                     return 6;
-                case "ナムコオリジナル":
+                case CStrジャンル.ナムコオリジナル:
                     return 7;
                 default:
                     return 8;
@@ -68,22 +68,22 @@
         {
             switch ( strジャンル )
             {
-                case "J-POP":
+                case CStrジャンル.JPOP:
                     return 1;
-                case "アニメ":
+                case CStrジャンル.アニメ:
                     return 2;
-                case "ゲームミュージック":
+                case CStrジャンル.ゲームミュージック:
                     return 3;
-                case "ナムコオリジナル":
+                case CStrジャンル.ナムコオリジナル:
                     return 4;
-                case "クラシック":
+                case CStrジャンル.クラシック:
                     return 5;
-                case "バラエティ":
+                case CStrジャンル.バラエティ:
                     return 6;
-                case "どうよう":
+                case CStrジャンル.どうよう:
                     return 7;
-                case "ボーカロイド":
-                case "VOCALOID":
+                case CStrジャンル.ボーカロイドJP:
+                case CStrジャンル.ボーカロイドEN:
                     return 8;
                 default:
                     return 0;
@@ -93,32 +93,6 @@
         internal static int ForGenreTextIndex( string strジャンル )
         {
             return ForAC8_14SortOrder( strジャンル );
-        }
-        
-        internal static string ForTextureFileName( string genreName )
-        {
-            switch (genreName)
-            {
-                case "アニメ":
-                    return "Anime";
-                case "J-POP":
-                    return "J-POP";
-                case "ゲームミュージック":
-                    return "Game";
-                case "ナムコオリジナル":
-                    return "Namco";
-                case "クラシック":
-                    return "Classic";
-                case "どうよう":
-                    return "Child";
-                case "バラエティ":
-                    return "Variety";
-                case "ボーカロイド":
-                case "VOCALOID":
-                    return "Vocaloid";
-                default:
-                    return null;
-            }
         }
     }
 }

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -28,7 +28,7 @@
             }
         }
 
-        internal static int ForAC15SortOrder(string strジャンル)
+        internal static int ForAC15SortOrder( string strジャンル )
         {
             switch (strジャンル)
             {
@@ -52,6 +52,37 @@
                 default:
                     return 8;
             }
+        }
+
+        internal static int ForGenreBackIndex( string strジャンル )
+        {
+            switch( strジャンル )
+            {
+                case "アニメ":
+                    return 2;
+                case "J-POP":
+                    return 1;
+                case "ゲームミュージック":
+                    return 3;
+                case "ナムコオリジナル":
+                    return 4;
+                case "クラシック":
+                    return 5;
+                case "どうよう":
+                    return 7;
+                case "バラエティ":
+                    return 6;
+                case "ボーカロイド":
+                case "VOCALOID":
+                    return 8;
+                default:
+                    return 0;
+            }
+        }
+
+        internal static int ForGenreTextIndex( string strジャンル )
+        {
+            return ForAC8_14SortOrder( strジャンル );
         }
     }
 }

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -56,33 +56,12 @@
 
         internal static int ForFrameBoxIndex( string strジャンル )
         {
-            switch ( strジャンル )
-            {
-                case "J-POP":
-                    return 1;
-                case "アニメ":
-                    return 2;
-                case "ゲームミュージック":
-                    return 3;
-                case "ナムコオリジナル":
-                    return 4;
-                case "クラシック":
-                    return 5;
-                case "バラエティ":
-                    return 6;
-                case "どうよう":
-                    return 7;
-                case "ボーカロイド":
-                case "VOCALOID":
-                    return 8;
-                default:
-                    return 0;
-            }
+            return ForGenreBackIndex( strジャンル );
         }
 
         internal static int ForGenreBackIndex( string strジャンル )
         {
-            switch( strジャンル )
+            switch ( strジャンル )
             {
                 case "J-POP":
                     return 1;

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -28,29 +28,29 @@
             }
         }
 
-        public static int ForAC15SortOrder( string strジャンル )
+        public static EジャンルAC15SortOrder ForAC15SortOrder( string strジャンル )
         {
             switch ( strジャンル )
             {
                 case CStrジャンル.JPOP:
-                    return 0;
+                    return EジャンルAC15SortOrder.JPOP;
                 case CStrジャンル.アニメ:
-                    return 1;
+                    return EジャンルAC15SortOrder.アニメ;
                 case CStrジャンル.ボーカロイドJP:
                 case CStrジャンル.ボーカロイドEN:
-                    return 2;
+                    return EジャンルAC15SortOrder.ボーカロイド;
                 case CStrジャンル.どうよう:
-                    return 3;
+                    return EジャンルAC15SortOrder.どうよう;
                 case CStrジャンル.バラエティ:
-                    return 4;
+                    return EジャンルAC15SortOrder.バラエティ;
                 case CStrジャンル.クラシック:
-                    return 5;
+                    return EジャンルAC15SortOrder.クラシック;
                 case CStrジャンル.ゲームミュージック:
-                    return 6;
+                    return EジャンルAC15SortOrder.ゲームミュージック;
                 case CStrジャンル.ナムコオリジナル:
-                    return 7;
+                    return EジャンルAC15SortOrder.ナムコオリジナル;
                 default:
-                    return 8;
+                    return EジャンルAC15SortOrder.Unknown;
             }
         }
 

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -54,6 +54,32 @@
             }
         }
 
+        internal static int ForBarGenreIndex( string strジャンル )
+        {
+            switch ( strジャンル )
+            {
+                case "J-POP":
+                    return 1;
+                case "アニメ":
+                    return 2;
+                case "ゲームミュージック":
+                    return 3;
+                case "ナムコオリジナル":
+                    return 4;
+                case "クラシック":
+                    return 5;
+                case "バラエティ":
+                    return 6;
+                case "どうよう":
+                    return 7;
+                case "ボーカロイド":
+                case "VOCALOID":
+                    return 8;
+                default:
+                    return 0;
+            }
+        }
+
         internal static int ForFrameBoxIndex( string strジャンル )
         {
             return ForGenreBackIndex( strジャンル );

--- a/TJAPlayer3/Songs/CStrジャンルtoNum.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoNum.cs
@@ -1,8 +1,8 @@
 ﻿namespace TJAPlayer3
 {
-    internal static class CStrジャンルtoNum
+    public static class CStrジャンルtoNum
     {
-        internal static int ForAC8_14SortOrder( string strジャンル )
+        public static int ForAC8_14SortOrder( string strジャンル )
         {
             switch( strジャンル )
             {
@@ -28,7 +28,7 @@
             }
         }
 
-        internal static int ForAC15SortOrder( string strジャンル )
+        public static int ForAC15SortOrder( string strジャンル )
         {
             switch ( strジャンル )
             {
@@ -54,17 +54,17 @@
             }
         }
 
-        internal static int ForBarGenreIndex( string strジャンル )
+        public static int ForBarGenreIndex( string strジャンル )
         {
             return ForGenreBackIndex( strジャンル );
         }
 
-        internal static int ForFrameBoxIndex( string strジャンル )
+        public static int ForFrameBoxIndex( string strジャンル )
         {
             return ForGenreBackIndex( strジャンル );
         }
 
-        internal static int ForGenreBackIndex( string strジャンル )
+        public static int ForGenreBackIndex( string strジャンル )
         {
             switch ( strジャンル )
             {
@@ -90,7 +90,7 @@
             }
         }
 
-        internal static int ForGenreTextIndex( string strジャンル )
+        public static int ForGenreTextIndex( string strジャンル )
         {
             return ForAC8_14SortOrder( strジャンル );
         }

--- a/TJAPlayer3/Songs/CStrジャンルtoStr.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoStr.cs
@@ -1,0 +1,31 @@
+﻿namespace TJAPlayer3
+{
+    internal static class CStrジャンルtoStr
+    {
+        internal static string ForTextureFileName( string genreName )
+        {
+            switch (genreName)
+            {
+                case CStrジャンル.アニメ:
+                    return "Anime";
+                case CStrジャンル.JPOP:
+                    return CStrジャンル.JPOP;
+                case CStrジャンル.ゲームミュージック:
+                    return "Game";
+                case CStrジャンル.ナムコオリジナル:
+                    return "Namco";
+                case CStrジャンル.クラシック:
+                    return "Classic";
+                case CStrジャンル.どうよう:
+                    return "Child";
+                case CStrジャンル.バラエティ:
+                    return "Variety";
+                case CStrジャンル.ボーカロイドJP:
+                case CStrジャンル.ボーカロイドEN:
+                    return "Vocaloid";
+                default:
+                    return null;
+            }
+        }
+    }
+}

--- a/TJAPlayer3/Songs/CStrジャンルtoStr.cs
+++ b/TJAPlayer3/Songs/CStrジャンルtoStr.cs
@@ -1,10 +1,10 @@
 ﻿namespace TJAPlayer3
 {
-    internal static class CStrジャンルtoStr
+    public static class CStrジャンルtoStr
     {
-        internal static string ForTextureFileName( string genreName )
+        public static string ForTextureFileName( string strジャンル )
         {
-            switch (genreName)
+            switch (strジャンル)
             {
                 case CStrジャンル.アニメ:
                     return "Anime";

--- a/TJAPlayer3/Songs/C曲リストノード.cs
+++ b/TJAPlayer3/Songs/C曲リストノード.cs
@@ -55,7 +55,6 @@ namespace TJAPlayer3
 		public string strSkinPath = "";			// #28195 2012.5.4 yyagi; box.defでのスキン切り替え対応
         public bool bBranch = false;
         public int[] nLevel = new int[(int)Difficulty.Total]{ 0, 0, 0, 0, 0, 0, 0 };
-        public Eジャンル eジャンル = Eジャンル.None;
 		
 		// コンストラクタ
 

--- a/TJAPlayer3/Songs/C曲リストノードComparers/C曲リストノードComparerAC15.cs
+++ b/TJAPlayer3/Songs/C曲リストノードComparers/C曲リストノードComparerAC15.cs
@@ -6,7 +6,7 @@ namespace TJAPlayer3.C曲リストノードComparers
     {
         public int Compare(C曲リストノード n1, C曲リストノード n2)
         {
-            return CStrジャンルtoNum.ForAC15(n1.strジャンル).CompareTo(CStrジャンルtoNum.ForAC15(n2.strジャンル));
+            return CStrジャンルtoNum.ForAC15SortOrder(n1.strジャンル).CompareTo(CStrジャンルtoNum.ForAC15SortOrder(n2.strジャンル));
         }
     }
 }

--- a/TJAPlayer3/Songs/C曲リストノードComparers/C曲リストノードComparerAC8_14.cs
+++ b/TJAPlayer3/Songs/C曲リストノードComparers/C曲リストノードComparerAC8_14.cs
@@ -6,7 +6,7 @@ namespace TJAPlayer3.C曲リストノードComparers
     {
         public int Compare(C曲リストノード n1, C曲リストノード n2)
         {
-            return CStrジャンルtoNum.ForAC8_14(n1.strジャンル).CompareTo(CStrジャンルtoNum.ForAC8_14(n2.strジャンル));
+            return CStrジャンルtoNum.ForAC8_14SortOrder(n1.strジャンル).CompareTo(CStrジャンルtoNum.ForAC8_14SortOrder(n2.strジャンル));
         }
     }
 }

--- a/TJAPlayer3/Songs/EジャンルAC15SortOrder.cs
+++ b/TJAPlayer3/Songs/EジャンルAC15SortOrder.cs
@@ -1,0 +1,15 @@
+﻿namespace TJAPlayer3
+{
+    public enum EジャンルAC15SortOrder
+    {
+        JPOP = 0,
+        アニメ = 1,
+        ボーカロイド = 2,
+        どうよう = 3,
+        バラエティ = 4,
+        クラシック = 5,
+        ゲームミュージック = 6,
+        ナムコオリジナル = 7,
+        Unknown = 8
+    }
+}

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -1940,92 +1940,14 @@ namespace TJAPlayer3
 			if( x >= SampleFramework.GameWindowSize.Width || y >= SampleFramework.GameWindowSize.Height )
 				return;
 
-            var rc = new Rectangle( 0, 48, 128, 48 );
+		    if (strジャンル == "難易度ソート")
+		    {
+		        this.tx曲バー_難易度[ this.n現在選択中の曲の現在の難易度レベル ]?.t2D描画( TJAPlayer3.app.Device, x, y );
+		        return;
+		    }
 
-			switch( strジャンル )
-            {
-                case "J-POP":
-				    #region [ J-POP ]
-    				//-----------------
-	    			if( TJAPlayer3.Tx.SongSelect_Bar_Genre[1] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[1].t2D描画(TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "アニメ":
-				    #region [ アニメ ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[2] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[2].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "ゲームミュージック":
-				    #region [ ゲーム ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[3] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[3].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "ナムコオリジナル":
-				    #region [ ナムコオリジナル ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[4] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[4].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "クラシック":
-				    #region [ クラシック ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[5] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[5].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "バラエティ":
-				    #region [ バラエティ ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[6] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[6].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "どうよう":
-				    #region [ どうよう ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[7] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[7].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "ボーカロイド":
-                case "VOCALOID":
-				    #region [ ボカロ ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[8] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[8].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                case "難易度ソート":
-				    #region [ 難易度ソート ]
-    				//-----------------
-	    			if( this.tx曲バー_難易度[ this.n現在選択中の曲の現在の難易度レベル ] != null )
-		    			this.tx曲バー_難易度[ this.n現在選択中の曲の現在の難易度レベル ].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-                default:
-				    #region [ その他の場合 ]
-    				//-----------------
-	    			if(TJAPlayer3.Tx.SongSelect_Bar_Genre[0] != null )
-                        TJAPlayer3.Tx.SongSelect_Bar_Genre[0].t2D描画( TJAPlayer3.app.Device, x, y );
-	    			//-----------------
-		    		#endregion
-                    break;
-			}
+            var barGenreIndex = CStrジャンルtoNum.ForBarGenreIndex( strジャンル );
+		    TJAPlayer3.Tx.SongSelect_Bar_Genre[barGenreIndex]?.t2D描画( TJAPlayer3.app.Device, x, y );
 		}
 
         private TitleTextureKey ttk曲名テクスチャを生成する( string str文字, Color forecolor, Color backcolor)

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -1167,82 +1167,8 @@ namespace TJAPlayer3
                             break;
 
                         case C曲リストノード.Eノード種別.BOX:
-                            switch (r現在選択中の曲.strジャンル)
-                            {
-                                case "J-POP":
-                                    #region [ J-POP ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[1] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[1].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "アニメ":
-                                    #region [ アニメ ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[2] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[2].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "ゲームミュージック":
-                                    #region [ ゲーム ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[3] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[3].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "ナムコオリジナル":
-                                    #region [ ナムコオリジナル ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[4] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[4].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "クラシック":
-                                    #region [ クラシック ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[5] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[5].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "バラエティ":
-                                    #region [ バラエティ ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[6] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[6].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "どうよう":
-                                    #region [ どうよう ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[7] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[7].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "ボーカロイド":
-                                case "VOCALOID":
-                                    #region [ ボカロ ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[8] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[8].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                default:
-                                    #region [ その他の場合 ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[0] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[0].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                            }
+                            var frameBoxIndex = CStrジャンルtoNum.ForFrameBoxIndex(r現在選択中の曲.strジャンル);
+                            TJAPlayer3.Tx.SongSelect_Frame_Box[frameBoxIndex]?.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
                             break;
 
                         case C曲リストノード.Eノード種別.BACKBOX:
@@ -1504,82 +1430,8 @@ namespace TJAPlayer3
                             break;
 
                         case C曲リストノード.Eノード種別.BOX:
-                            switch (r現在選択中の曲.strジャンル)
-                            {
-                                case "J-POP":
-                                    #region [ J-POP ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[1] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[1].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "アニメ":
-                                    #region [ アニメ ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[2] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[2].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "ゲームミュージック":
-                                    #region [ ゲーム ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[3] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[3].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "ナムコオリジナル":
-                                    #region [ ナムコオリジナル ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[4] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[4].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "クラシック":
-                                    #region [ クラシック ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[5] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[5].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "バラエティ":
-                                    #region [ バラエティ ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[6] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[6].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "どうよう":
-                                    #region [ どうよう ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[7] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[7].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                case "ボーカロイド":
-                                case "VOCALOID":
-                                    #region [ ボカロ ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[8] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[8].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                                default:
-                                    #region [ その他の場合 ]
-                                    //-----------------
-                                    if (TJAPlayer3.Tx.SongSelect_Frame_Box[0] != null)
-                                        TJAPlayer3.Tx.SongSelect_Frame_Box[0].t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
-                                    //-----------------
-                                    #endregion
-                                    break;
-                            }
+                            var frameBoxIndex = CStrジャンルtoNum.ForFrameBoxIndex(r現在選択中の曲.strジャンル);
+                            TJAPlayer3.Tx.SongSelect_Frame_Box[frameBoxIndex]?.t2D描画(TJAPlayer3.app.Device, 450, TJAPlayer3.Skin.SongSelect_Overall_Y);
                             break;
 
                         case C曲リストノード.Eノード種別.BACKBOX:

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -1708,10 +1708,10 @@ namespace TJAPlayer3
 			tアイテム数の描画();
 			#endregion
 
-            if( this.e曲のバー種別を返す( this.r現在選択中の曲 ) == Eバー種別.Score && this.nStrジャンルtoNum( this.r現在選択中の曲.strジャンル ) != 8 )
+            if( this.e曲のバー種別を返す( this.r現在選択中の曲 ) == Eバー種別.Score && CStrジャンルtoNum.ForGenreTextIndex( this.r現在選択中の曲.strジャンル ) != 8 )
             {
                 if( TJAPlayer3.Tx.SongSelect_GenreText != null )
-                    TJAPlayer3.Tx.SongSelect_GenreText.t2D描画( TJAPlayer3.app.Device, 496, TJAPlayer3.Skin.SongSelect_Overall_Y-64, new Rectangle( 0, 60 * this.nStrジャンルtoNum( this.r現在選択中の曲.strジャンル ), 288, 60 ) );
+                    TJAPlayer3.Tx.SongSelect_GenreText.t2D描画( TJAPlayer3.app.Device, 496, TJAPlayer3.Skin.SongSelect_Overall_Y-64, new Rectangle( 0, 60 * CStrジャンルtoNum.ForGenreTextIndex( this.r現在選択中の曲.strジャンル ), 288, 60 ) );
             }
 
 
@@ -2175,44 +2175,6 @@ namespace TJAPlayer3
                     break;
 			}
 		}
-        private int nStrジャンルtoNum( string strジャンル )
-        {
-            int nGenre = 8;
-            switch( strジャンル )
-            {
-                case "アニメ":
-                    nGenre = 0;
-                    break;
-                case "J-POP":
-                    nGenre = 1;
-                    break;
-                case "ゲームミュージック":
-                    nGenre = 2;
-                    break;
-                case "ナムコオリジナル":
-                    nGenre = 3;
-                    break;
-                case "クラシック":
-                    nGenre = 4;
-                    break;
-                case "どうよう":
-                    nGenre = 5;
-                    break;
-                case "バラエティ":
-                    nGenre = 6;
-                    break;
-                case "ボーカロイド":
-                case "VOCALOID":
-                    nGenre = 7;
-                    break;
-                default:
-                    nGenre = 8;
-                    break;
-
-            }
-
-            return nGenre;
-        }
 
         private TitleTextureKey ttk曲名テクスチャを生成する( string str文字, Color forecolor, Color backcolor)
         {

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -298,7 +298,7 @@ namespace TJAPlayer3
 
 			        if (this.r現在選択中の曲 != null)
 			        {
-			            var genreBack = TJAPlayer3.Tx.SongSelect_GenreBack[this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル)];
+			            var genreBack = TJAPlayer3.Tx.SongSelect_GenreBack[CStrジャンルtoNum.ForGenreBackIndex(this.r現在選択中の曲.strジャンル)];
 			            if (genreBack != null)
 			            {
 			                var width = TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width;
@@ -1009,45 +1009,7 @@ namespace TJAPlayer3
 			}
 		}
 
-        private int nStrジャンルtoNum( string strジャンル )
-        {
-            int nGenre = 8;
-            switch( strジャンル )
-            {
-                case "アニメ":
-                    nGenre = 2;
-                    break;
-                case "J-POP":
-                    nGenre = 1;
-                    break;
-                case "ゲームミュージック":
-                    nGenre = 3;
-                    break;
-                case "ナムコオリジナル":
-                    nGenre = 4;
-                    break;
-                case "クラシック":
-                    nGenre = 5;
-                    break;
-                case "どうよう":
-                    nGenre = 7;
-                    break;
-                case "バラエティ":
-                    nGenre = 6;
-                    break;
-                case "ボーカロイド":
-                case "VOCALOID":
-                    nGenre = 8;
-                    break;
-                default:
-                    nGenre = 0;
-                    break;
-
-            }
-
-            return nGenre;
-        }
 		//-----------------
 		#endregion
-	}
+    }
 }

--- a/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CStage選曲.cs
@@ -292,21 +292,25 @@ namespace TJAPlayer3
 
 				this.ct登場時アニメ用共通.t進行();
 
-				if( TJAPlayer3.Tx.SongSelect_Background != null )
-                    TJAPlayer3.Tx.SongSelect_Background.t2D描画( TJAPlayer3.app.Device, 0, 0 );
+			    if (TJAPlayer3.Tx.SongSelect_Background != null)
+			    {
+			        TJAPlayer3.Tx.SongSelect_Background.t2D描画(TJAPlayer3.app.Device, 0, 0);
 
-                if( this.r現在選択中の曲 != null )
-                {
-                    if (TJAPlayer3.Tx.SongSelect_GenreBack[ this.nStrジャンルtoNum( this.r現在選択中の曲.strジャンル ) ] != null )
-                    {
-                        for( int i = 0 ; i <(1280 / TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width) + 2; i++ )
-                            if (TJAPlayer3.Tx.SongSelect_GenreBack[ this.nStrジャンルtoNum( this.r現在選択中の曲.strジャンル ) ] != null )
-                                    TJAPlayer3.Tx.SongSelect_GenreBack[this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル)].t2D描画(TJAPlayer3.app.Device, -ct背景スクロール用タイマー.n現在の値 + TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width * i , 0);
-                    }
-                }
+			        if (this.r現在選択中の曲 != null)
+			        {
+			            var genreBack = TJAPlayer3.Tx.SongSelect_GenreBack[this.nStrジャンルtoNum(this.r現在選択中の曲.strジャンル)];
+			            if (genreBack != null)
+			            {
+			                var width = TJAPlayer3.Tx.SongSelect_Background.szテクスチャサイズ.Width;
+			                for (int i = 0; i < (1280 / width) + 2; i++)
+			                {
+			                    genreBack.t2D描画(TJAPlayer3.app.Device, -ct背景スクロール用タイマー.n現在の値 + width * i, 0);
+			                }
+			            }
+			        }
+			    }
 
-
-				//this.actPreimageパネル.On進行描画();
+			    //this.actPreimageパネル.On進行描画();
 			//	this.bIsEnumeratingSongs = !this.actPreimageパネル.bIsPlayingPremovie;				// #27060 2011.3.2 yyagi: #PREMOVIE再生中は曲検索を中断する
 
 				this.act曲リスト.On進行描画();

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -1,9 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Drawing;
 using System.Diagnostics;
-using SlimDX;
 using FDK;
 
 namespace TJAPlayer3

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -79,7 +79,7 @@ namespace TJAPlayer3
 				}
 
 			    this.txGENRE?.Dispose();
-                var genreTextureFileName = CStrジャンルtoNum.ForTextureFileName( genreName );
+                var genreTextureFileName = CStrジャンルtoStr.ForTextureFileName( genreName );
 			    this.txGENRE = genreTextureFileName == null ? null : TJAPlayer3.Tx.TxCGen(genreTextureFileName);
 
 			    this.ct進行用 = new CCounter( 0, 2000, 2, TJAPlayer3.Timer );

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -80,54 +80,13 @@ namespace TJAPlayer3
 						this.txPanel = null;
 					}
 				}
-                if( !string.IsNullOrEmpty(genreName) )
-                {
-                    if(genreName.Equals( "アニメ" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("Anime");
-                    }
-                    else if(genreName.Equals( "J-POP" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("J-POP");
-                    }
-                    else if(genreName.Equals( "ゲームミュージック" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("Game");
-                    }
-                    else if(genreName.Equals( "ナムコオリジナル" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("Namco");
-                    }
-                    else if(genreName.Equals( "クラシック" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("Classic");
-                    }
-                    else if(genreName.Equals( "どうよう" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("Child");
-                    }
-                    else if(genreName.Equals( "バラエティ" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("Variety");
-                    }
-                    else if(genreName.Equals( "ボーカロイド" ) || genreName.Equals( "VOCALOID" ) )
-                    {
-                        this.txGENRE = TJAPlayer3.Tx.TxCGen("Vocaloid");
-                    }
-                    else
-                    {
-                        using (var bmpDummy = new Bitmap( 1, 1 ))
-                        {
-                            this.txGENRE = TJAPlayer3.tテクスチャの生成( bmpDummy, true );
-                        }
-                    }
-                }
+
+			    this.txGENRE?.Dispose();
+                var textureFileName = CStrジャンルtoNum.ForTextureFileName( genreName );
+			    this.txGENRE = textureFileName == null ? null : TJAPlayer3.Tx.TxCGen(textureFileName);
 
 			    this.ct進行用 = new CCounter( 0, 2000, 2, TJAPlayer3.Timer );
 				this.Start();
-
-
-
 			}
 		}
 

--- a/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏パネル文字列.cs
@@ -79,8 +79,8 @@ namespace TJAPlayer3
 				}
 
 			    this.txGENRE?.Dispose();
-                var textureFileName = CStrジャンルtoNum.ForTextureFileName( genreName );
-			    this.txGENRE = textureFileName == null ? null : TJAPlayer3.Tx.TxCGen(textureFileName);
+                var genreTextureFileName = CStrジャンルtoNum.ForTextureFileName( genreName );
+			    this.txGENRE = genreTextureFileName == null ? null : TJAPlayer3.Tx.TxCGen(genreTextureFileName);
 
 			    this.ct進行用 = new CCounter( 0, 2000, 2, TJAPlayer3.Timer );
 				this.Start();

--- a/TJAPlayer3/TJAPlayer3.csproj
+++ b/TJAPlayer3/TJAPlayer3.csproj
@@ -129,7 +129,9 @@
     <Compile Include="Songs\CDTXCompanionFileFinder.cs" />
     <Compile Include="Songs\CDTXStyleExtractor.cs" />
     <Compile Include="Songs\CScoreIni.cs" />
+    <Compile Include="Songs\CStrジャンル.cs" />
     <Compile Include="Songs\CStrジャンルtoNum.cs" />
+    <Compile Include="Songs\CStrジャンルtoStr.cs" />
     <Compile Include="Songs\C曲リストノードComparers\ComparerChain.cs" />
     <Compile Include="Songs\C曲リストノードComparers\C曲リストノードComparerAC15.cs" />
     <Compile Include="Songs\C曲リストノードComparers\C曲リストノードComparerAC8_14.cs" />

--- a/TJAPlayer3/TJAPlayer3.csproj
+++ b/TJAPlayer3/TJAPlayer3.csproj
@@ -139,6 +139,7 @@
     <Compile Include="Songs\C曲リストノードComparers\C曲リストノードComparerノード種別.cs" />
     <Compile Include="Songs\C曲リストノードComparers\C曲リストノードComparer絶対パス.cs" />
     <Compile Include="Songs\Dan-C.cs" />
+    <Compile Include="Songs\EジャンルAC15SortOrder.cs" />
     <Compile Include="Stages\01.StartUp\TextureLoader.cs" />
     <Compile Include="Stages\02.Title\CActScanningLoudness.cs" />
     <Compile Include="Stages\02.Title\CEnumSongs.cs" />


### PR DESCRIPTION
TJAPlayer3 has grown a lot of copy/paste code over the years.

When copy/paste coding is allowed, over time it produces:
* larger code that is harder to read and maintain
* larger code that uses more memory and executes more slowly (usually due to causing CPU cache misses)
* inconsistencies and bugs when copies of code are not modified together consistently
* etc.

One of the most common kinds of copy/paste coding in TJAPlayer3 regularly appears in if/else and switch logic whose branches execute nearly identical code. This can usually be avoided by separating responsibilities between:
* mapping from one type of value to another, for example from a genre string to an integer index value
* acting on the resulting value

When reading the diff for recent PR #250, I noticed this kind of copy/paste code being added to TJAPlayer3. I thought it would make for a good example case where I could show some techniques for fixing and avoiding copy/paste code problems.

In the new code, note that:
* magic strings for genre names are now all collected in one location
* code mapping from those magic strings to various index and enum values are now all collected nearby one another.
* actions performed using the resulting mapped (integer) values are no longer duplicated.

Notably: Nearly 480 lines of production code has been replaced with 190 lines of production code, for a net reduction of 290 lines of production code. The new production code is supported by nearly 185 lines of new test code to verify it and keep it consistent over time.

Note that some inconsistencies still remain, visible in the various methods of CStrジャンルtoNum, but that these are now necessary to keep because of other code and files that have grown around the copied code.

If you accept this PR, in the future we can refer people to this PR and its code when they submit a PR that has too much copy/paste coding in it.