### PR TITLE
レーン周りの座標自由化

### DIFF
--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -910,11 +910,11 @@ namespace TJAPlayer3
                             //-----------------------------
                             else if (strCommand == "ScrollFieldP1Y")
                             {
-                                this.nScrollFieldY[0] = C変換.n値を文字列から取得して返す(strParam, 192);
+                                this.Game_Lane_Field_Y[0] = C変換.n値を文字列から取得して返す(strParam, 192);
                             }
                             else if (strCommand == "ScrollFieldP2Y")
                             {
-                                this.nScrollFieldY[1] = C変換.n値を文字列から取得して返す(strParam, 192);
+                                this.Game_Lane_Field_Y[1] = C変換.n値を文字列から取得して返す(strParam, 192);
                             }
                             else if (strCommand == "SENotesP1Y")
                             {
@@ -926,11 +926,11 @@ namespace TJAPlayer3
                             }
                             else if (strCommand == "JudgePointP1Y")
                             {
-                                this.nJudgePointY[0] = C変換.n値を文字列から取得して返す(strParam, this.nJudgePointY[0]);
+                                this.Game_Lane_JudgePoint_Y[0] = C変換.n値を文字列から取得して返す(strParam, this.Game_Lane_JudgePoint_Y[0]);
                             }
                             else if (strCommand == "JudgePointP2Y")
                             {
-                                this.nJudgePointY[1] = C変換.n値を文字列から取得して返す(strParam, this.nJudgePointY[1]);
+                                this.Game_Lane_JudgePoint_Y[1] = C変換.n値を文字列から取得して返す(strParam, this.Game_Lane_JudgePoint_Y[1]);
                             }
 
                             else if (strCommand == "DiffDispMode")
@@ -1165,6 +1165,7 @@ namespace TJAPlayer3
                             }
                             #endregion
                             #region Game
+
                             else if (strCommand == "Game_Notes_Anime")
                             {
                                 Game_Notes_Anime = C変換.bONorOFF(strParam[0]);
@@ -1446,6 +1447,14 @@ namespace TJAPlayer3
                             }
                             #endregion
                             #region Taiko
+                            else if (strCommand == nameof(Game_Taiko_Background_X))
+                            {
+                                Game_Taiko_Background_X = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
+                            else if (strCommand == nameof(Game_Taiko_Background_Y))
+                            {
+                                Game_Taiko_Background_Y = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
                             else if (strCommand == "Game_Taiko_NamePlate_X")
                             {
                                 string[] strSplit = strParam.Split(',');
@@ -1939,6 +1948,33 @@ namespace TJAPlayer3
                                 Game_Effect_FireWorks_Timing = int.Parse(strParam);
                             }
                             #endregion
+                            #region Lane
+                            else if (strCommand == nameof(Game_Lane_Field_X))
+                            {
+                                Game_Lane_Field_X = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
+                            else if (strCommand == nameof(Game_Lane_Field_Y))
+                            {
+                                Game_Lane_Field_Y = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
+                            else if (strCommand == nameof(Game_Lane_Background_X))
+                            {
+                                Game_Lane_Background_X = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
+                            //else if (strCommand == nameof(nScrollFieldBGY))
+                            //{
+                            //    nScrollFieldBGY = strParam.Split(',').Select(int.Parse).ToArray();
+                            //}
+                            else if (strCommand == nameof(Game_Lane_JudgePoint_X))
+                            {
+                                Game_Lane_JudgePoint_X = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
+                            else if (strCommand == nameof(Game_Lane_JudgePoint_Y))
+                            {
+                                Game_Lane_JudgePoint_Y = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
+
+                            #endregion
                             #region Runner
                             else if (strCommand == "Game_Runner_Size")
                             {
@@ -2258,24 +2294,13 @@ namespace TJAPlayer3
 
         #region[ 座標 ]
         //2017.08.11 kairera0467 DP実用化に向けてint配列に変更
-
-        //フィールド位置　Xは判定枠部分の位置。Yはフィールドの最上部の座標。
-        //現時点ではノーツ画像、Senotes画像、判定枠が連動する。
-        //Xは中央基準描画、Yは左上基準描画
-        public int[] nScrollFieldX = new int[] { 414, 414 };
-        public int[] nScrollFieldY = new int[] { 192, 368 };
-
-        //中心座標指定
-        public int[] nJudgePointX = new int[] { 413, 413, 413, 413 };
-        public int[] nJudgePointY = new int[] { 256, 433, 0, 0 };
+        //2019.01.05 rhimm 自由化のため、レーン座標・判定枠関連を 新・SkinConfig>Lane 下に移動
 
         //フィールド背景画像
         //ScrollField座標への追従設定が可能。
         //分岐背景、ゴーゴー背景が連動する。(全て同じ大きさ、位置で作成すること。)
         //左上基準描画
         public bool bFieldBgPointOverride = false;
-        public int[] nScrollFieldBGX = new int[] { 333, 333, 333, 333 };
-        public int[] nScrollFieldBGY = new int[] { 192, 368, 0, 0 };
 
         //SEnotes
         //音符座標に加算
@@ -2485,6 +2510,8 @@ namespace TJAPlayer3
         public int[] Game_Score_Size = new int[] { 24, 40 };
         #endregion
         #region Taiko
+        public int[] Game_Taiko_Background_X = new int[] { 0, 0 };
+        public int[] Game_Taiko_Background_Y = new int[] { 184, 360 };
         public int[] Game_Taiko_NamePlate_X = new int[] { 0, 0 };
         public int[] Game_Taiko_NamePlate_Y = new int[] { 288, 368 };
         public int[] Game_Taiko_PlayerNumber_X = new int[] { 4, 4 };
@@ -2576,6 +2603,23 @@ namespace TJAPlayer3
         public bool Game_Effect_Fire_AddBlend = true;
         public bool Game_Effect_GoGoSplash_AddBlend = true;
         public int Game_Effect_FireWorks_Timing = 8;
+        #endregion
+        #region Lane
+
+        //フィールド位置　Xは判定枠部分の位置。Yはフィールドの最上部の座標。
+        //現時点ではノーツ画像、Senotes画像、判定枠が連動する。
+        //Xは中央基準描画、Yは左上基準描画
+        public int[] Game_Lane_Field_X = new int[] { 414, 414 };
+        public int[] Game_Lane_Field_Y = new int[] { 192, 368 };
+        //中心座標指定
+        public int[] Game_Lane_JudgePoint_X = new int[] { 413, 413, 413, 413 };     //これ使われてないな(rhimm)
+        public int[] Game_Lane_JudgePoint_Y = new int[] { 256, 433, 0, 0 };
+        //フィールド背景画像
+        //ScrollField座標への追従設定が可能。
+        //分岐背景、ゴーゴー背景が連動する。(全て同じ大きさ、位置で作成すること。)
+        //左上基準描画
+        public int[] Game_Lane_Background_X = new int[] { 333, 333, 333, 333 };
+        public int[] nScrollFieldBGY = new int[] { 192, 368, 0, 0 };    //これ使われてないな(rhimm)
         #endregion
         #region Runner
         public int[] Game_Runner_Size = new int[] { 60, 125 };

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -1612,6 +1612,14 @@ namespace TJAPlayer3
                             }
                             #endregion
                             #region Gauge
+                            else if (strCommand == nameof(Game_Gauge_X))
+                            {
+                                Game_Gauge_X = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
+                            else if (strCommand == nameof(Game_Gauge_Y))
+                            {
+                                Game_Gauge_Y = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
                             else if (strCommand == "Game_Gauge_Rainbow_Timer")
                             {
                                 if (int.Parse(strParam) != 0)
@@ -2533,6 +2541,8 @@ namespace TJAPlayer3
         public int[] Game_Taiko_Combo_Text_Size = new int[] { 100, 50 };
         #endregion
         #region Gauge
+        public int[] Game_Gauge_X = new int[] { 492, 492 };
+        public int[] Game_Gauge_Y = new int[] { 144, 532 };
         public int Game_Gauge_Rainbow_Ptn;
         public int Game_Gauge_Rainbow_Timer = 50;
         #endregion

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -907,15 +907,15 @@ namespace TJAPlayer3
                             #endregion
 
                             #region[ 演奏 ]
-                            //-----------------------------
-                            else if (strCommand == "ScrollFieldP1Y")
-                            {
-                                this.Game_Lane_Field_Y[0] = C変換.n値を文字列から取得して返す(strParam, 192);
-                            }
-                            else if (strCommand == "ScrollFieldP2Y")
-                            {
-                                this.Game_Lane_Field_Y[1] = C変換.n値を文字列から取得して返す(strParam, 192);
-                            }
+                            //新・SkinConfig　レーン下に移動
+                            //else if (strCommand == "ScrollFieldP1Y")
+                            //{
+                            //    this.Game_Lane_Field_Y[0] = C変換.n値を文字列から取得して返す(strParam, 192);
+                            //}
+                            //else if (strCommand == "ScrollFieldP2Y")
+                            //{
+                            //    this.Game_Lane_Field_Y[1] = C変換.n値を文字列から取得して返す(strParam, 192);
+                            //}
                             else if (strCommand == "SENotesP1Y")
                             {
                                 this.nSENotesY[0] = C変換.n値を文字列から取得して返す(strParam, this.nSENotesY[0]);
@@ -924,14 +924,14 @@ namespace TJAPlayer3
                             {
                                 this.nSENotesY[1] = C変換.n値を文字列から取得して返す(strParam, this.nSENotesY[1]);
                             }
-                            else if (strCommand == "JudgePointP1Y")
-                            {
-                                this.Game_Lane_JudgePoint_Y[0] = C変換.n値を文字列から取得して返す(strParam, this.Game_Lane_JudgePoint_Y[0]);
-                            }
-                            else if (strCommand == "JudgePointP2Y")
-                            {
-                                this.Game_Lane_JudgePoint_Y[1] = C変換.n値を文字列から取得して返す(strParam, this.Game_Lane_JudgePoint_Y[1]);
-                            }
+                            //else if (strCommand == "JudgePointP1Y")
+                            //{
+                            //    this.Game_Lane_JudgePoint_Y[0] = C変換.n値を文字列から取得して返す(strParam, this.Game_Lane_JudgePoint_Y[0]);
+                            //}
+                            //else if (strCommand == "JudgePointP2Y")
+                            //{
+                            //    this.Game_Lane_JudgePoint_Y[1] = C変換.n値を文字列から取得して返す(strParam, this.Game_Lane_JudgePoint_Y[1]);
+                            //}
 
                             else if (strCommand == "DiffDispMode")
                             {
@@ -1969,6 +1969,10 @@ namespace TJAPlayer3
                             {
                                 Game_Lane_Background_X = strParam.Split(',').Select(int.Parse).ToArray();
                             }
+                            else if (strCommand == nameof(Game_Lane_Background_Y))
+                            {
+                                Game_Lane_Background_Y = strParam.Split(',').Select(int.Parse).ToArray();
+                            }
                             //else if (strCommand == nameof(nScrollFieldBGY))
                             //{
                             //    nScrollFieldBGY = strParam.Split(',').Select(int.Parse).ToArray();
@@ -2623,13 +2627,14 @@ namespace TJAPlayer3
         public int[] Game_Lane_Field_Y = new int[] { 192, 368 };
         //中心座標指定
         public int[] Game_Lane_JudgePoint_X = new int[] { 413, 413, 413, 413 };     //これ使われてないな(rhimm)
-        public int[] Game_Lane_JudgePoint_Y = new int[] { 256, 433, 0, 0 };
+        public int[] Game_Lane_JudgePoint_Y = new int[] { 256, 433, 0, 0 };         //これも使わない方針(rhimm)
         //フィールド背景画像
         //ScrollField座標への追従設定が可能。
         //分岐背景、ゴーゴー背景が連動する。(全て同じ大きさ、位置で作成すること。)
         //左上基準描画
         public int[] Game_Lane_Background_X = new int[] { 333, 333, 333, 333 };
-        public int[] nScrollFieldBGY = new int[] { 192, 368, 0, 0 };    //これ使われてないな(rhimm)
+        public int[] Game_Lane_Background_Y = new int[] { 192, 368, 0, 0 };
+        //JudgePointの変わりにこれとこれに判定枠テクスチャサイズの半分を足した値を使っていきたい(rhimm)
         #endregion
         #region Runner
         public int[] Game_Runner_Size = new int[] { 60, 125 };

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -1181,7 +1181,14 @@ namespace TJAPlayer3
                             {
                                 Game_JudgeFrame_AddBlend = C変換.bONorOFF(strParam[0]);
                             }
-
+                            else if (strCommand == nameof(Game_Bar_Width))
+                            {
+                                Game_Bar_Width = int.Parse(strParam);
+                            }
+                            else if (strCommand == nameof(Game_Bar_Height))
+                            {
+                                Game_Bar_Height = int.Parse(strParam);
+                            }
                             #region CourseSymbol
                             else if (strCommand == "Game_CourseSymbol_X")
                             {
@@ -2404,6 +2411,8 @@ namespace TJAPlayer3
         public string Game_StageText = "1曲目";
         public RollColorMode Game_RollColorMode = RollColorMode.All;
         public bool Game_JudgeFrame_AddBlend = true;
+        public int Game_Bar_Width = 3;
+        public int Game_Bar_Height = 130;
         #region Chara
         public int[] Game_Chara_X = new int[] { 0, 0 };
         public int[] Game_Chara_Y = new int[] { 0, 537 };

--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -253,6 +253,7 @@ namespace TJAPlayer3
         {
             public double db移動時間;
             public int n移動距離px;
+            public int n移動距離Ypx;
             public int n移動方向; //移動方向は0(左)、1(右)の2つだけ。
             public int n内部番号;
             public int n表記上の番号;
@@ -264,6 +265,7 @@ namespace TJAPlayer3
                 {
                     builder.Append(string.Format("CJPOSSCROLL{0}(内部{1})", CDTX.tZZ(this.n表記上の番号), this.n内部番号));
                 }
+
                 else
                 {
                     builder.Append(string.Format("CJPOSSCROLL{0}", CDTX.tZZ(this.n表記上の番号)));
@@ -3768,26 +3770,65 @@ namespace TJAPlayer3
             }
             else if (command == "#JPOSSCROLL")
             {
-                strArray = argument.Split(chDelimiter);
-                WarnSplitLength("#JPOSSCROLL", strArray, 3);
-                double db移動時刻 = Convert.ToDouble(strArray[0]);
-                int n移動px = Convert.ToInt32(strArray[1]);
-                int n移動方向 = Convert.ToInt32(strArray[2]);
+                //SCROLL同様、iが含まれれば二次元移動するJPOSSCROLLとみなす
+                if (argument.IndexOf('i') != -1)
+                {
+                    //スクロールと記入方法を揃えるために、文字を置換しまくる・・・
+                    //「#JPOSSCROLL 3 100 100i 0」のように、「+」を省略して間にスペースを入れても
+                    //反応してくれます・・・たぶん(20190105 rhimm)
+                    StringBuilder rep = new StringBuilder(argument);
+                    rep.Replace("+", " ");
+                    rep.Replace(" -", "-");
+                    rep.Replace("-", " -");
+                    rep.Replace("i", "");
+                    
+                    string reparg = rep.ToString();
+                    strArray = reparg.Split(chDelimiter);
 
-                //チップ追加して割り込んでみる。
-                var chip = new CChip();
+                    WarnSplitLength("#JPOSSCROLL", strArray, 4);
+                    double db移動時刻 = Convert.ToDouble(strArray[0]);
+                    int n移動px = Convert.ToInt32(strArray[1]);
+                    int n移動Ypx = Convert.ToInt32(strArray[2]);
+                    int n移動方向 = Convert.ToInt32(strArray[3]);
 
-                chip.nチャンネル番号 = 0xE2;
-                chip.n発声位置 = ((this.n現在の小節数) * 384) - 1;
-                chip.n発声時刻ms = (int)this.dbNowTime;
-                chip.n整数値_内部番号 = 0;
-                chip.nコース = this.n現在のコース;
+                    //チップ追加して割り込んでみる。
+                    var chip = new CChip();
 
-                // チップを配置。
+                    chip.nチャンネル番号 = 0xE2;
+                    chip.n発声位置 = ((this.n現在の小節数) * 384) - 1;
+                    chip.n発声時刻ms = (int)this.dbNowTime;
+                    chip.n整数値_内部番号 = 0;
+                    chip.nコース = this.n現在のコース;
 
-                this.listJPOSSCROLL.Add(this.n内部番号JSCROLL1to, new CJPOSSCROLL() { n内部番号 = this.n内部番号JSCROLL1to, n表記上の番号 = 0, db移動時間 = db移動時刻, n移動距離px = n移動px, n移動方向 = n移動方向 });
-                this.listChip.Add(chip);
-                this.n内部番号JSCROLL1to++;
+                    // チップを配置。
+
+                    this.listJPOSSCROLL.Add(this.n内部番号JSCROLL1to, new CJPOSSCROLL() { n内部番号 = this.n内部番号JSCROLL1to, n表記上の番号 = 0, db移動時間 = db移動時刻, n移動距離px = n移動px, n移動距離Ypx = n移動Ypx, n移動方向 = n移動方向 });
+                    this.listChip.Add(chip);
+                    this.n内部番号JSCROLL1to++;
+                }
+                else
+                {
+                    strArray = argument.Split(chDelimiter);
+                    WarnSplitLength("#JPOSSCROLL", strArray, 3);
+                    double db移動時刻 = Convert.ToDouble(strArray[0]);
+                    int n移動px = Convert.ToInt32(strArray[1]);
+                    int n移動方向 = Convert.ToInt32(strArray[2]);
+
+                    //チップ追加して割り込んでみる。
+                    var chip = new CChip();
+
+                    chip.nチャンネル番号 = 0xE2;
+                    chip.n発声位置 = ((this.n現在の小節数) * 384) - 1;
+                    chip.n発声時刻ms = (int)this.dbNowTime;
+                    chip.n整数値_内部番号 = 0;
+                    chip.nコース = this.n現在のコース;
+
+                    // チップを配置。
+
+                    this.listJPOSSCROLL.Add(this.n内部番号JSCROLL1to, new CJPOSSCROLL() { n内部番号 = this.n内部番号JSCROLL1to, n表記上の番号 = 0, db移動時間 = db移動時刻, n移動距離px = n移動px, n移動距離Ypx = 0, n移動方向 = n移動方向 });
+                    this.listChip.Add(chip);
+                    this.n内部番号JSCROLL1to++;
+                }
             }
             else if (command == "#SENOTECHANGE")
             {

--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -3436,6 +3436,7 @@ namespace TJAPlayer3
 						if ( !pChip.bHit && ( pChip.nバーからの距離dot.Drums < 0 ) )
 						{
 							pChip.bHit = true;
+
 							//if ( dTX.listSCROLL.ContainsKey( pChip.n整数値_内部番号 ) )
 							//{
 								//this.actPlayInfo.dbBPM = ( dTX.listBPM[ pChip.n整数値_内部番号 ].dbBPM値 * ( ( (double) configIni.n演奏速度 ) / 20.0 ) );// + dTX.BASEBPM;
@@ -3659,11 +3660,11 @@ namespace TJAPlayer3
                         {
                             if (nPlayer == 0)
                             {
-                                TJAPlayer3.stage演奏ドラム画面.actLaneTaiko.t判定枠移動(dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].db移動時間, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動距離px, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動方向);
+                                TJAPlayer3.stage演奏ドラム画面.actLaneTaiko.t判定枠移動XY(dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].db移動時間, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動距離px, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動距離Ypx, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動方向);
                             }
                             else
                             {
-                                TJAPlayer3.stage演奏ドラム画面.actLaneTaiko.t判定枠移動2(dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].db移動時間, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動距離px, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動方向);
+                                TJAPlayer3.stage演奏ドラム画面.actLaneTaiko.t判定枠移動XY2(dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].db移動時間, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動距離px, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動距離Ypx, dTX.listJPOSSCROLL[nJPOSSCROLL[nPlayer]].n移動方向);
                             }
                             this.nJPOSSCROLL[ nPlayer ]++;
                             pChip.bHit = true;

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsMtaiko.cs
@@ -147,15 +147,15 @@ namespace TJAPlayer3
 
             //if(CDTXMania.Tx.Taiko_Frame[ 0 ] != null )
                // CDTXMania.Tx.Taiko_Frame[ 0 ].t2D描画( CDTXMania.app.Device, 0, 184 );
-            if(TJAPlayer3.Tx.Taiko_Background[0] != null )
-                TJAPlayer3.Tx.Taiko_Background[0].t2D描画( TJAPlayer3.app.Device, 0, 184 );
+            if(TJAPlayer3.Tx.Taiko_Background[0] != null ) 
+                TJAPlayer3.Tx.Taiko_Background[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[0], TJAPlayer3.Skin.Game_Taiko_Background_Y[0] );
 
             if ( TJAPlayer3.stage演奏ドラム画面.bDoublePlay )
             {
                 //if(CDTXMania.Tx.Taiko_Frame[ 1 ] != null )
                     //CDTXMania.Tx.Taiko_Frame[ 1 ].t2D描画( CDTXMania.app.Device, 0, 360 );
                 if(TJAPlayer3.Tx.Taiko_Background[1] != null )
-                    TJAPlayer3.Tx.Taiko_Background[1].t2D描画( TJAPlayer3.app.Device, 0, 360 );
+                    TJAPlayer3.Tx.Taiko_Background[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Taiko_Background_X[1], TJAPlayer3.Skin.Game_Taiko_Background_Y[1]);
             }
             
             if(TJAPlayer3.Tx.Taiko_Base != null )

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsゲージ.cs
@@ -220,16 +220,16 @@ namespace TJAPlayer3
 
                 if( TJAPlayer3.Tx.Gauge_Base[0] != null )
                 {
-                    TJAPlayer3.Tx.Gauge_Base[0].t2D描画( TJAPlayer3.app.Device, 492, 144, new Rectangle( 0, 0, 700, 44 ) );
+                    TJAPlayer3.Tx.Gauge_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0], new Rectangle( 0, 0, 700, 44 ) );
                 }
                 if( TJAPlayer3.stage演奏ドラム画面.bDoublePlay && TJAPlayer3.Tx.Gauge_Base[1] != null )
                 {
-                    TJAPlayer3.Tx.Gauge_Base[1].t2D描画( TJAPlayer3.app.Device, 492, 532, new Rectangle( 0, 0, 700, 44 ) );
+                    TJAPlayer3.Tx.Gauge_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1], new Rectangle( 0, 0, 700, 44 ) );
                 }
                 #region[ ゲージ1P ]
                 if( TJAPlayer3.Tx.Gauge[0] != null )
                 {
-                    TJAPlayer3.Tx.Gauge[0].t2D描画( TJAPlayer3.app.Device, 492, 144, new Rectangle( 0, 0, nRectX, 44 ) );
+                    TJAPlayer3.Tx.Gauge[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0], new Rectangle( 0, 0, nRectX, 44 ) );
 
                     if(TJAPlayer3.Tx.Gauge_Line[0] != null )
                     {
@@ -240,21 +240,22 @@ namespace TJAPlayer3
                             if(TJAPlayer3.Tx.Gauge_Rainbow[ this.ct虹アニメ.n現在の値 ] != null )
                             {
 				TJAPlayer3.Tx.Gauge_Rainbow[this.ct虹アニメ.n現在の値].n透明度 = 255;
-				TJAPlayer3.Tx.Gauge_Rainbow[this.ct虹アニメ.n現在の値].t2D描画(TJAPlayer3.app.Device, 492, 144);
+				TJAPlayer3.Tx.Gauge_Rainbow[this.ct虹アニメ.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0]);
                                 TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].n透明度 = (ct虹透明度.n現在の値 * 255 / ct虹透明度.n終了値)/1;
-                                TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].t2D描画(TJAPlayer3.app.Device, 492, 144);
+                                TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0]);
                             }
                         }
-                        TJAPlayer3.Tx.Gauge_Line[0].t2D描画( TJAPlayer3.app.Device, 492, 144 );
+                        TJAPlayer3.Tx.Gauge_Line[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0]);
                     }
                     #region[ 「クリア」文字 ]
-                    if( this.db現在のゲージ値[ 0 ] >= 80.0 )
+                    //1038 - 492 = 546
+                    if ( this.db現在のゲージ値[ 0 ] >= 80.0 )
                     {
-                        TJAPlayer3.Tx.Gauge[0].t2D描画( TJAPlayer3.app.Device, 1038, 144, new Rectangle( 0, 44, 58, 24 ) );
+                        TJAPlayer3.Tx.Gauge[0].t2D描画( TJAPlayer3.app.Device, 546 + TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0], new Rectangle( 0, 44, 58, 24 ) );
                     }
                     else
                     {
-                        TJAPlayer3.Tx.Gauge[0].t2D描画( TJAPlayer3.app.Device, 1038, 144, new Rectangle( 58, 44, 58, 24 ) );
+                        TJAPlayer3.Tx.Gauge[0].t2D描画( TJAPlayer3.app.Device, 546 + TJAPlayer3.Skin.Game_Gauge_X[0], TJAPlayer3.Skin.Game_Gauge_Y[0], new Rectangle( 58, 44, 58, 24 ) );
                     }
                     #endregion
                 }
@@ -262,7 +263,7 @@ namespace TJAPlayer3
                 #region[ ゲージ2P ]
                 if( TJAPlayer3.stage演奏ドラム画面.bDoublePlay && TJAPlayer3.Tx.Gauge[1] != null )
                 {
-                    TJAPlayer3.Tx.Gauge[1].t2D描画( TJAPlayer3.app.Device, 492, 532, new Rectangle( 0, 0, nRectX2P, 44 ) );
+                    TJAPlayer3.Tx.Gauge[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1], new Rectangle( 0, 0, nRectX2P, 44 ) );
                     if(TJAPlayer3.Tx.Gauge[1] != null )
                     {
                         if (this.db現在のゲージ値[1] >= 100.0)
@@ -272,21 +273,23 @@ namespace TJAPlayer3
                             if (TJAPlayer3.Tx.Gauge_Rainbow[this.ct虹アニメ.n現在の値] != null)
                             {
                                 TJAPlayer3.Tx.Gauge_Rainbow[ct虹アニメ.n現在の値].n透明度 = 255;
-                                TJAPlayer3.Tx.Gauge_Rainbow[ct虹アニメ.n現在の値].t2D上下反転描画(TJAPlayer3.app.Device, 492, 532);
+                                TJAPlayer3.Tx.Gauge_Rainbow[ct虹アニメ.n現在の値].t2D上下反転描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
                                 TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].n透明度 = (ct虹透明度.n現在の値 * 255 / ct虹透明度.n終了値) / 1;
-                                TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].t2D上下反転描画(TJAPlayer3.app.Device, 492, 532);
+                                TJAPlayer3.Tx.Gauge_Rainbow[虹ベース].t2D上下反転描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
                             }
                         }
-                        TJAPlayer3.Tx.Gauge_Line[1].t2D描画( TJAPlayer3.app.Device, 492, 532 );
+                        TJAPlayer3.Tx.Gauge_Line[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Gauge_X[1], TJAPlayer3.Skin.Game_Gauge_Y[1]);
                     }
                     #region[ 「クリア」文字 ]
+                    //1038 - 492 = 546
+                    //554 - 532 = 12
                     if( this.db現在のゲージ値[ 1 ] >= 80.0 )
                     {
-                        TJAPlayer3.Tx.Gauge[1].t2D描画( TJAPlayer3.app.Device, 1038, 554, new Rectangle( 0, 44, 58, 24 ) );
+                        TJAPlayer3.Tx.Gauge[1].t2D描画( TJAPlayer3.app.Device, 546 + TJAPlayer3.Skin.Game_Gauge_X[1], 12 + TJAPlayer3.Skin.Game_Gauge_Y[1], new Rectangle( 0, 44, 58, 24 ) );
                     }
                     else
                     {
-                        TJAPlayer3.Tx.Gauge[1].t2D描画( TJAPlayer3.app.Device, 1038, 554, new Rectangle( 58, 44, 58, 24 ) );
+                        TJAPlayer3.Tx.Gauge[1].t2D描画( TJAPlayer3.app.Device, 546 + TJAPlayer3.Skin.Game_Gauge_X[1], 12 + TJAPlayer3.Skin.Game_Gauge_Y[1], new Rectangle( 58, 44, 58, 24 ) );
                     }
                     #endregion
                 }
@@ -297,12 +300,13 @@ namespace TJAPlayer3
                 {
                     //仮置き
                     int[] nSoulFire = new int[] { 52, 443, 0, 0 };
+                    //1112 - 492 = 620
                     for( int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++ )
                     {
                         if( this.db現在のゲージ値[ i ] >= 100.0 )
                         {
                             this.ct炎.t進行Loop();
-                            TJAPlayer3.Tx.Gauge_Soul_Fire.t2D描画( TJAPlayer3.app.Device, 1112, nSoulFire[ i ], new Rectangle( 230 * ( this.ct炎.n現在の値 ), 0, 230, 230 ) );
+                            TJAPlayer3.Tx.Gauge_Soul_Fire.t2D描画( TJAPlayer3.app.Device, 620 + TJAPlayer3.Skin.Game_Gauge_X[i], TJAPlayer3.Skin.Game_Gauge_Y[i] - nDefaultGaugeY[i] + nSoulFire[ i ], new Rectangle( 230 * ( this.ct炎.n現在の値 ), 0, 230, 230 ) );
                         }
                     }
                 }
@@ -310,15 +314,16 @@ namespace TJAPlayer3
                 {
                     //仮置き
                     int[] nSoulY = new int[] { 125, 516, 0, 0 };
+                    //1184 - 492 = 692
                     for( int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++ )
                     {
                         if( this.db現在のゲージ値[ i ] >= 80.0 )
                         {
-                            TJAPlayer3.Tx.Gauge_Soul.t2D描画( TJAPlayer3.app.Device, 1184, nSoulY[ i ], new Rectangle( 0, 0, 80, 80 ) );
+                            TJAPlayer3.Tx.Gauge_Soul.t2D描画( TJAPlayer3.app.Device, 692 + TJAPlayer3.Skin.Game_Gauge_X[i], TJAPlayer3.Skin.Game_Gauge_Y[i] - nDefaultGaugeY[i] + nSoulY[ i ], new Rectangle( 0, 0, 80, 80 ) );
                         }
                         else
                         {
-                            TJAPlayer3.Tx.Gauge_Soul.t2D描画( TJAPlayer3.app.Device, 1184, nSoulY[ i ], new Rectangle( 0, 80, 80, 80 ) );
+                            TJAPlayer3.Tx.Gauge_Soul.t2D描画( TJAPlayer3.app.Device, 692 + TJAPlayer3.Skin.Game_Gauge_X[i], TJAPlayer3.Skin.Game_Gauge_Y[i] - nDefaultGaugeY[i] + nSoulY[ i ], new Rectangle( 0, 80, 80, 80 ) );
                         }
                     }
                 }
@@ -382,10 +387,11 @@ namespace TJAPlayer3
 		}
 
 
-		// その他
+        // その他
 
-		#region [ private ]
-		//-----------------
+        #region [ private ]
+        //-----------------
+        private int[] nDefaultGaugeY = new int[] { 144, 532, 0, 0 };
         protected STSTATUS[] st花火状態 = new STSTATUS[ 32 ];
         protected STSTATUS[] st花火状態2P = new STSTATUS[ 32 ];
         [StructLayout(LayoutKind.Sequential)]

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsチップファイアD.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsチップファイアD.cs
@@ -259,8 +259,8 @@ namespace TJAPlayer3
 					        if( TJAPlayer3.Tx.Effects_Hit_Explosion != null && !TJAPlayer3.IsPerformingCalibration )
 					        {
                                 int n = this.st状態[ i ].nIsBig == 1 ? 520 : 0;
-                                int nX = ( TJAPlayer3.Skin.nScrollFieldX[ this.st状態[ i ].nPlayer ] ) - ( (TJAPlayer3.Tx.Effects_Hit_Explosion.sz画像サイズ.Width / 7 ) / 2 );
-                                int nY = ( TJAPlayer3.Skin.nJudgePointY[ this.st状態[ i ].nPlayer ] ) - ( (TJAPlayer3.Tx.Effects_Hit_Explosion.sz画像サイズ.Height / 4 ) / 2 );
+                                int nX = ( TJAPlayer3.Skin.Game_Lane_Field_X[ this.st状態[ i ].nPlayer ] ) - ( (TJAPlayer3.Tx.Effects_Hit_Explosion.sz画像サイズ.Width / 7 ) / 2 );
+                                int nY = ( TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[ this.st状態[ i ].nPlayer ] ) - ( (TJAPlayer3.Tx.Effects_Hit_Explosion.sz画像サイズ.Height / 4 ) / 2 );
 
                                 switch( st状態[ i ].judge )
                                 {
@@ -307,7 +307,7 @@ namespace TJAPlayer3
                                     if( this.st状態_大[ i ].nIsBig == 1 )
                                     {
                                         float fX = 415 - ((TJAPlayer3.Tx.Effects_Hit_Explosion_Big.sz画像サイズ.Width * TJAPlayer3.Tx.Effects_Hit_Explosion_Big.vc拡大縮小倍率.X ) / 2.0f);
-                                        float fY = TJAPlayer3.Skin.nJudgePointY[ this.st状態_大[ i ].nPlayer ] - ((TJAPlayer3.Tx.Effects_Hit_Explosion_Big.sz画像サイズ.Height * TJAPlayer3.Tx.Effects_Hit_Explosion_Big.vc拡大縮小倍率.Y ) / 2.0f);
+                                        float fY = TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[ this.st状態_大[ i ].nPlayer ] - ((TJAPlayer3.Tx.Effects_Hit_Explosion_Big.sz画像サイズ.Height * TJAPlayer3.Tx.Effects_Hit_Explosion_Big.vc拡大縮小倍率.Y ) / 2.0f);
                                         //float fY = 257 - ((this.txアタックエフェクトUpper_big.sz画像サイズ.Height * this.txアタックエフェクトUpper_big.vc拡大縮小倍率.Y ) / 2.0f);
 
                                         ////7
@@ -319,7 +319,7 @@ namespace TJAPlayer3
 
                                         Matrix mat = Matrix.Identity;
                                         mat *= Matrix.Scaling( f倍率, f倍率, f倍率 );
-                                        mat *= Matrix.Translation( TJAPlayer3.Skin.nScrollFieldX[0] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.nJudgePointY[ this.st状態[ i ].nPlayer ] - SampleFramework.GameWindowSize.Height / 2.0f), 0f );
+                                        mat *= Matrix.Translation( TJAPlayer3.Skin.Game_Lane_Field_X[0] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[ this.st状態[ i ].nPlayer ] - SampleFramework.GameWindowSize.Height / 2.0f), 0f );
                                         //mat *= Matrix.Billboard( new Vector3( 15, 15, 15 ), new Vector3(0, 0, 0), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 0 ) );
                                         //mat *= Matrix.Translation( 0f, 0f, 0f );
 
@@ -342,7 +342,7 @@ namespace TJAPlayer3
 
                 for (int i = 0; i < 45; i++)
                 {
-                    if( TJAPlayer3.Skin.nScrollFieldX[0] != 414 )
+                    if( TJAPlayer3.Skin.Game_Lane_Field_X[0] != 414 )
                         break;
 
                     if (this.st大音符花火[i].b使用中)

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsチップファイアD.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏DrumsチップファイアD.cs
@@ -260,7 +260,7 @@ namespace TJAPlayer3
 					        {
                                 int n = this.st状態[ i ].nIsBig == 1 ? 520 : 0;
                                 int nX = ( TJAPlayer3.Skin.Game_Lane_Field_X[ this.st状態[ i ].nPlayer ] ) - ( (TJAPlayer3.Tx.Effects_Hit_Explosion.sz画像サイズ.Width / 7 ) / 2 );
-                                int nY = ( TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[ this.st状態[ i ].nPlayer ] ) - ( (TJAPlayer3.Tx.Effects_Hit_Explosion.sz画像サイズ.Height / 4 ) / 2 );
+                                int nY = ( TJAPlayer3.Skin.Game_Lane_Field_Y[ this.st状態[ i ].nPlayer ] ) + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height/2) - ( (TJAPlayer3.Tx.Effects_Hit_Explosion.sz画像サイズ.Height / 4 ) / 2 );
 
                                 switch( st状態[ i ].judge )
                                 {
@@ -307,7 +307,7 @@ namespace TJAPlayer3
                                     if( this.st状態_大[ i ].nIsBig == 1 )
                                     {
                                         float fX = 415 - ((TJAPlayer3.Tx.Effects_Hit_Explosion_Big.sz画像サイズ.Width * TJAPlayer3.Tx.Effects_Hit_Explosion_Big.vc拡大縮小倍率.X ) / 2.0f);
-                                        float fY = TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[ this.st状態_大[ i ].nPlayer ] - ((TJAPlayer3.Tx.Effects_Hit_Explosion_Big.sz画像サイズ.Height * TJAPlayer3.Tx.Effects_Hit_Explosion_Big.vc拡大縮小倍率.Y ) / 2.0f);
+                                        float fY = TJAPlayer3.Skin.Game_Lane_Field_Y[ this.st状態_大[ i ].nPlayer ] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - ((TJAPlayer3.Tx.Effects_Hit_Explosion_Big.sz画像サイズ.Height * TJAPlayer3.Tx.Effects_Hit_Explosion_Big.vc拡大縮小倍率.Y ) / 2.0f);
                                         //float fY = 257 - ((this.txアタックエフェクトUpper_big.sz画像サイズ.Height * this.txアタックエフェクトUpper_big.vc拡大縮小倍率.Y ) / 2.0f);
 
                                         ////7
@@ -319,7 +319,7 @@ namespace TJAPlayer3
 
                                         Matrix mat = Matrix.Identity;
                                         mat *= Matrix.Scaling( f倍率, f倍率, f倍率 );
-                                        mat *= Matrix.Translation( TJAPlayer3.Skin.Game_Lane_Field_X[0] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[ this.st状態[ i ].nPlayer ] - SampleFramework.GameWindowSize.Height / 2.0f), 0f );
+                                        mat *= Matrix.Translation( TJAPlayer3.Skin.Game_Lane_Field_X[0] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.Game_Lane_Field_Y[ this.st状態[ i ].nPlayer ] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - SampleFramework.GameWindowSize.Height / 2.0f), 0f );
                                         //mat *= Matrix.Billboard( new Vector3( 15, 15, 15 ), new Vector3(0, 0, 0), new Vector3( 0, 0, 0 ), new Vector3( 0, 0, 0 ) );
                                         //mat *= Matrix.Translation( 0f, 0f, 0f );
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン.cs
@@ -87,73 +87,73 @@ namespace TJAPlayer3
                         if( nBefore[ i ] == 0 && nAfter[ i ] == 1 )
                         {
                             TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
-                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                         }
                         //普通→達人
                         if( nBefore[ i ] == 0 && nAfter[ i ] == 2)
                         {
-                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             if( this.ct分岐アニメ進行[ i ].n現在の値 < 100 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 100 && this.ct分岐アニメ進行[ i ].n現在の値 < 150 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 150 )
                             {
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                                 TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 250 ? 255 : ( ( (this.ct分岐アニメ進行[ i ].n現在の値 - 150) * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             }
                         }
                         #endregion
                         #region[ 玄人譜面_レベルアップ ]
                         if( nBefore[ i ] == 1 && nAfter[ i ] == 2 )
                         {
-                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                         }
                         #endregion
                         #region[ 玄人譜面_レベルダウン ]
                         if( nBefore[ i ] == 1 && nAfter[ i ] == 0)
                         {
-                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                         }
                         #endregion
                         #region[ 達人譜面_レベルダウン ]
                         if( nBefore[ i ] == 2 && nAfter[ i ] == 0)
                         {
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             if( this.ct分岐アニメ進行[ i ].n現在の値 < 100 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 100 && this.ct分岐アニメ進行[ i ].n現在の値 < 150 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 150 )
                             {
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                                 TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 250 ? 255 : ( ( ( this.ct分岐アニメ進行[ i ].n現在の値 - 150 ) * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             }
                         }
                         if( nBefore[ i ] == 2 && nAfter[ i ] == 1 )
                         {
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                             TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[ i ], TJAPlayer3.Skin.nScrollFieldY[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
                         }
                         #endregion
                     }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン.cs
@@ -87,73 +87,73 @@ namespace TJAPlayer3
                         if( nBefore[ i ] == 0 && nAfter[ i ] == 1 )
                         {
                             TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
-                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                         }
                         //普通→達人
                         if( nBefore[ i ] == 0 && nAfter[ i ] == 2)
                         {
-                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             if( this.ct分岐アニメ進行[ i ].n現在の値 < 100 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 100 && this.ct分岐アニメ進行[ i ].n現在の値 < 150 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 150 )
                             {
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                                 TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 250 ? 255 : ( ( (this.ct分岐アニメ進行[ i ].n現在の値 - 150) * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             }
                         }
                         #endregion
                         #region[ 玄人譜面_レベルアップ ]
                         if( nBefore[ i ] == 1 && nAfter[ i ] == 2 )
                         {
-                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                         }
                         #endregion
                         #region[ 玄人譜面_レベルダウン ]
                         if( nBefore[ i ] == 1 && nAfter[ i ] == 0)
                         {
-                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                         }
                         #endregion
                         #region[ 達人譜面_レベルダウン ]
                         if( nBefore[ i ] == 2 && nAfter[ i ] == 0)
                         {
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             if( this.ct分岐アニメ進行[ i ].n現在の値 < 100 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 100 && this.ct分岐アニメ進行[ i ].n現在の値 < 150 )
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             }
                             else if( this.ct分岐アニメ進行[ i ].n現在の値 >= 150 )
                             {
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                                 TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 250 ? 255 : ( ( ( this.ct分岐アニメ進行[ i ].n現在の値 - 150 ) * 0xff ) / 100 );
-                                TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                                TJAPlayer3.Tx.Lane_Base[0].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             }
                         }
                         if( nBefore[ i ] == 2 && nAfter[ i ] == 1 )
                         {
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                             TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.ct分岐アニメ進行[ i ].n現在の値 > 100 ? 255 : ( ( this.ct分岐アニメ進行[ i ].n現在の値 * 0xff ) / 100 );
-                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Field_Y[ i ] );
+                            TJAPlayer3.Tx.Lane_Base[2].t2D描画( TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[ i ], TJAPlayer3.Skin.Game_Lane_Background_Y[ i ] );
                         }
                         #endregion
                     }

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
@@ -150,7 +150,7 @@ namespace TJAPlayer3
             {
                 for (int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++)
                 {
-                    TJAPlayer3.Tx.Lane_Background_Main.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                    TJAPlayer3.Tx.Lane_Background_Main.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                 }
             }
             #endregion
@@ -204,21 +204,21 @@ namespace TJAPlayer3
                             if (TJAPlayer3.Tx.Lane_Base[0] != null)
                             {
                                 TJAPlayer3.Tx.Lane_Base[0].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                             }
                             break;
                         case 1:
                             if (TJAPlayer3.Tx.Lane_Base[1] != null)
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                             }
                             break;
                         case 2:
                             if (TJAPlayer3.Tx.Lane_Base[2] != null)
                             {
                                 TJAPlayer3.Tx.Lane_Base[2].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                             }
                             break;
                     }
@@ -243,9 +243,9 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[0] != null && TJAPlayer3.Tx.Lane_Base[1] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             //普通→達人
@@ -257,8 +257,8 @@ namespace TJAPlayer3
                                 }
                                 if (TJAPlayer3.Tx.Lane_Base[0] != null && TJAPlayer3.Tx.Lane_Base[2] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -268,8 +268,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[1] != null && TJAPlayer3.Tx.Lane_Base[2] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -279,8 +279,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[1] != null && TJAPlayer3.Tx.Lane_Base[0] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -290,8 +290,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[2] != null && TJAPlayer3.Tx.Lane_Base[0] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -319,27 +319,27 @@ namespace TJAPlayer3
                     if (this.ctゴーゴー.n現在の値 <= 4)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.2f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 54);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 54);
                     }
                     else if (this.ctゴーゴー.n現在の値 <= 5)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.4f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 40);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 40);
                     }
                     else if (this.ctゴーゴー.n現在の値 <= 6)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.6f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 26);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 26);
                     }
                     else if (this.ctゴーゴー.n現在の値 <= 8)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.8f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 13);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 13);
                     }
                     else if (this.ctゴーゴー.n現在の値 >= 9)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 1.0f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                     }
                 }
                 #endregion
@@ -357,15 +357,15 @@ namespace TJAPlayer3
                             {
                                 case 0:
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     break;
                                 case 1:
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     break;
                                 case 2:
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     break;
                             }
                         }
@@ -384,14 +384,14 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 30) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 30) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
 
                             }
@@ -405,9 +405,9 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 12) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 12) + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 //if( this.stBranch[ i ].ct分岐アニメ進行.n現在の値 >= 5 && this.stBranch[ i ].ct分岐アニメ進行.n現在の値 < 60 )
                                 //{
@@ -419,21 +419,21 @@ namespace TJAPlayer3
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 60 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 150)
                                 {
                                     this.stBranch[i].nY = 21;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 150 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 210)
                                 {
                                     this.stBranch[i].nY = ((this.stBranch[i].ct分岐アニメ進行.n現在の値 - 150) / 2);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             #endregion
@@ -449,12 +449,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             #endregion
@@ -469,12 +469,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             #endregion
@@ -489,27 +489,27 @@ namespace TJAPlayer3
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 60));
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 60 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 150)
                                 {
                                     this.stBranch[i].nY = 21;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 150 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 210)
                                 {
                                     this.stBranch[i].nY = ((this.stBranch[i].ct分岐アニメ進行.n現在の値 - 150) / 2);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 210)
                                 {
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             if (this.stBranch[i].nBefore == 2 && this.stBranch[i].nAfter == 1)
@@ -522,12 +522,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
 
                             }
@@ -651,12 +651,16 @@ namespace TJAPlayer3
                 if (n移動方向 == 1)
                 {
                     TJAPlayer3.Skin.Game_Lane_Field_X[0] = this.n移動開始X + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
+                    TJAPlayer3.Skin.Game_Lane_Field_Y[0] = this.n移動開始Y + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離Ypx);
                     TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointX[0] = this.n移動開始X + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
+                    TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointY[0] = this.n移動開始Y + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離Ypx) + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2);
                 }
                 else
                 {
                     TJAPlayer3.Skin.Game_Lane_Field_X[0] = this.n移動開始X - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
+                    TJAPlayer3.Skin.Game_Lane_Field_Y[0] = this.n移動開始Y - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離Ypx);
                     TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointX[0] = this.n移動開始X - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
+                    TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointY[0] = this.n移動開始Y - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離Ypx) + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2);
                 }
 
                 if (((int)CSound管理.rc演奏用タイマ.n現在時刻ms) > this.n移動開始時刻 + this.n総移動時間)
@@ -669,12 +673,16 @@ namespace TJAPlayer3
                 if (n移動方向2 == 1)
                 {
                     TJAPlayer3.Skin.Game_Lane_Field_X[1] = this.n移動開始X2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
-                    TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_X[1] = this.n移動開始X2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
+                    TJAPlayer3.Skin.Game_Lane_Field_Y[1] = this.n移動開始Y2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離Ypx2);
+                    TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointX[1] = this.n移動開始X2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
+                    TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointY[1] = this.n移動開始Y2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離Ypx2) + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2);
                 }
                 else
                 {
                     TJAPlayer3.Skin.Game_Lane_Field_X[1] = this.n移動開始X2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
-                    TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_X[1] = this.n移動開始X2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
+                    TJAPlayer3.Skin.Game_Lane_Field_Y[1] = this.n移動開始Y2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離Ypx2);
+                    TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointX[1] = this.n移動開始X2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
+                    TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointY[1] = this.n移動開始Y2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離Ypx2) + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2);
                 }
 
 
@@ -791,14 +799,14 @@ namespace TJAPlayer3
 
                         Matrix mat = Matrix.Identity;
                         mat *= Matrix.Scaling(f倍率, f倍率, 1.0f);
-                        mat *= Matrix.Translation(TJAPlayer3.Skin.Game_Lane_Field_X[i] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - SampleFramework.GameWindowSize.Height / 2.0f), 0f);
+                        mat *= Matrix.Translation(TJAPlayer3.Skin.Game_Lane_Field_X[i] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - SampleFramework.GameWindowSize.Height / 2.0f), 0f);
 
                         //this.txゴーゴー炎.b加算合成 = true;
 
                         //this.ctゴーゴー.n現在の値 = 6;
                         if (this.ctゴーゴー.b終了値に達した)
                         {
-                            TJAPlayer3.Tx.Effects_Fire.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[i] - 180, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - (TJAPlayer3.Tx.Effects_Fire.szテクスチャサイズ.Height / 2), new Rectangle(360 * (this.ctゴーゴー炎.n現在の値), 0, 360, 370));
+                            TJAPlayer3.Tx.Effects_Fire.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[i] - 180, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - (TJAPlayer3.Tx.Effects_Fire.szテクスチャサイズ.Height / 2), new Rectangle(360 * (this.ctゴーゴー炎.n現在の値), 0, 360, 370));
                         }
                         else
                         {
@@ -829,17 +837,17 @@ namespace TJAPlayer3
                             case E判定.Auto:
                                 //this.txアタックエフェクトLower.t2D描画( CDTXMania.app.Device, 285, 127, new Rectangle( this.st状態[ i ].ct進行.n現在の値 * 260, n, 260, 260 ) );
                                 if (this.st状態[i].nIsBig == 1 && TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2);
                                 else if (TJAPlayer3.Tx.Effects_Hit_Great[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Great[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Great[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2);
                                 break;
 
                             case E判定.Good:
                                 //this.txアタックエフェクトLower.t2D描画( CDTXMania.app.Device, 285, 127, new Rectangle( this.st状態[ i ].ct進行.n現在の値 * 260, n + 260, 260, 260 ) );
                                 if (this.st状態[i].nIsBig == 1 && TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2);
                                 else if (TJAPlayer3.Tx.Effects_Hit_Good[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Good[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Good[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + (TJAPlayer3.Tx.Judge_Frame.szテクスチャサイズ.Height / 2) - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2);
                                 break;
 
                             case E判定.Miss:
@@ -909,22 +917,44 @@ namespace TJAPlayer3
             TJAPlayer3.stage演奏ドラム画面.actLane.t分岐レイヤー_コース変化(n現在, n次回, nPlayer);
         }
 
-        public void t判定枠移動(double db移動時間, int n移動px, int n移動方向)
+        //public void t判定枠移動(double db移動時間, int n移動px, int n移動方向)
+        //{
+        //    this.n移動開始時刻 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
+        //    this.n移動開始X = TJAPlayer3.Skin.Game_Lane_Field_X[0];
+        //    this.n総移動時間 = (int)(db移動時間 * 1000);
+        //    this.n移動方向 = n移動方向;
+        //    this.n移動距離px = n移動px;
+        //}
+
+        //public void t判定枠移動2(double db移動時間, int n移動px, int n移動方向)
+        //{
+        //    this.n移動開始時刻2 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
+        //    this.n移動開始X2 = TJAPlayer3.Skin.Game_Lane_Field_X[1];
+        //    this.n総移動時間2 = (int)(db移動時間 * 1000);
+        //    this.n移動方向2 = n移動方向;
+        //    this.n移動距離px2 = n移動px;
+        //}
+
+        public void t判定枠移動XY(double db移動時間, int n移動px, int n移動Ypx, int n移動方向)
         {
             this.n移動開始時刻 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
             this.n移動開始X = TJAPlayer3.Skin.Game_Lane_Field_X[0];
+            this.n移動開始Y = TJAPlayer3.Skin.Game_Lane_Field_Y[0];
             this.n総移動時間 = (int)(db移動時間 * 1000);
             this.n移動方向 = n移動方向;
             this.n移動距離px = n移動px;
+            this.n移動距離Ypx = n移動Ypx;
         }
 
-        public void t判定枠移動2(double db移動時間, int n移動px, int n移動方向)
+        public void t判定枠移動XY2(double db移動時間, int n移動px, int n移動Ypx, int n移動方向)
         {
             this.n移動開始時刻2 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
             this.n移動開始X2 = TJAPlayer3.Skin.Game_Lane_Field_X[1];
+            this.n移動開始Y2 = TJAPlayer3.Skin.Game_Lane_Field_Y[1];
             this.n総移動時間2 = (int)(db移動時間 * 1000);
             this.n移動方向2 = n移動方向;
             this.n移動距離px2 = n移動px;
+            this.n移動距離Ypx2 = n移動Ypx;
         }
         #region[ private ]
         //-----------------
@@ -985,13 +1015,17 @@ namespace TJAPlayer3
 
         private int n総移動時間;
         private int n移動開始X;
+        private int n移動開始Y;
         private int n移動開始時刻;
         private int n移動距離px;
+        private int n移動距離Ypx;
         private int n移動方向;
         private int n総移動時間2;
         private int n移動開始X2;
+        private int n移動開始Y2;
         private int n移動開始時刻2;
         private int n移動距離px2;
+        private int n移動距離Ypx2;
         private int n移動方向2;
 
         private int[] nDefaultJudgePos = new int[2];

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
@@ -37,8 +37,8 @@ namespace TJAPlayer3
 
             this.n総移動時間 = -1;
             this.n総移動時間2 = -1;
-            this.nDefaultJudgePos[0] = TJAPlayer3.Skin.nScrollFieldX[0];
-            this.nDefaultJudgePos[1] = TJAPlayer3.Skin.nScrollFieldY[0];
+            this.nDefaultJudgePos[0] = TJAPlayer3.Skin.Game_Lane_Field_X[0];
+            this.nDefaultJudgePos[1] = TJAPlayer3.Skin.Game_Lane_Field_Y[0];
             this.ctゴーゴー炎 = new CCounter(0, 6, 50, TJAPlayer3.Timer);
             base.On活性化();
         }
@@ -50,8 +50,8 @@ namespace TJAPlayer3
                 this.st状態[i].ct進行 = null;
                 this.stBranch[i].ct分岐アニメ進行 = null;
             }
-            TJAPlayer3.Skin.nScrollFieldX[0] = this.nDefaultJudgePos[0];
-            TJAPlayer3.Skin.nScrollFieldY[0] = this.nDefaultJudgePos[1];
+            TJAPlayer3.Skin.Game_Lane_Field_X[0] = this.nDefaultJudgePos[0];
+            TJAPlayer3.Skin.Game_Lane_Field_Y[0] = this.nDefaultJudgePos[1];
             this.ctゴーゴー = null;
 
             base.On非活性化();
@@ -150,7 +150,7 @@ namespace TJAPlayer3
             {
                 for (int i = 0; i < TJAPlayer3.ConfigIni.nPlayerCount; i++)
                 {
-                    TJAPlayer3.Tx.Lane_Background_Main.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i]);
+                    TJAPlayer3.Tx.Lane_Background_Main.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                 }
             }
             #endregion
@@ -204,21 +204,21 @@ namespace TJAPlayer3
                             if (TJAPlayer3.Tx.Lane_Base[0] != null)
                             {
                                 TJAPlayer3.Tx.Lane_Base[0].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i]);
+                                TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                             }
                             break;
                         case 1:
                             if (TJAPlayer3.Tx.Lane_Base[1] != null)
                             {
                                 TJAPlayer3.Tx.Lane_Base[1].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i]);
+                                TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                             }
                             break;
                         case 2:
                             if (TJAPlayer3.Tx.Lane_Base[2] != null)
                             {
                                 TJAPlayer3.Tx.Lane_Base[2].n透明度 = 255;
-                                TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i]);
+                                TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                             }
                             break;
                     }
@@ -243,9 +243,9 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[0] != null && TJAPlayer3.Tx.Lane_Base[1] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                 }
                             }
                             //普通→達人
@@ -257,8 +257,8 @@ namespace TJAPlayer3
                                 }
                                 if (TJAPlayer3.Tx.Lane_Base[0] != null && TJAPlayer3.Tx.Lane_Base[2] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -268,8 +268,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[1] != null && TJAPlayer3.Tx.Lane_Base[2] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -279,8 +279,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[1] != null && TJAPlayer3.Tx.Lane_Base[0] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -290,8 +290,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[2] != null && TJAPlayer3.Tx.Lane_Base[0] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -319,27 +319,27 @@ namespace TJAPlayer3
                     if (this.ctゴーゴー.n現在の値 <= 4)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.2f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i] + 54);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 54);
                     }
                     else if (this.ctゴーゴー.n現在の値 <= 5)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.4f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i] + 40);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 40);
                     }
                     else if (this.ctゴーゴー.n現在の値 <= 6)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.6f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i] + 26);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 26);
                     }
                     else if (this.ctゴーゴー.n現在の値 <= 8)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 0.8f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i] + 13);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 13);
                     }
                     else if (this.ctゴーゴー.n現在の値 >= 9)
                     {
                         TJAPlayer3.Tx.Lane_Background_GoGo.vc拡大縮小倍率.Y = 1.0f;
-                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[i], TJAPlayer3.Skin.nScrollFieldY[i]);
+                        TJAPlayer3.Tx.Lane_Background_GoGo.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                     }
                 }
                 #endregion
@@ -357,15 +357,15 @@ namespace TJAPlayer3
                             {
                                 case 0:
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     break;
                                 case 1:
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     break;
                                 case 2:
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     break;
                             }
                         }
@@ -384,14 +384,14 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] - 30) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 30) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                 }
 
                             }
@@ -405,35 +405,35 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] - 12) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 12) + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 //if( this.stBranch[ i ].ct分岐アニメ進行.n現在の値 >= 5 && this.stBranch[ i ].ct分岐アニメ進行.n現在の値 < 60 )
                                 //{
                                 //    this.stBranch[ i ].nY = this.stBranch[ i ].ct分岐アニメ進行.n現在の値 / 2;
-                                //    this.tx普通譜面[ 1 ].t2D描画(CDTXMania.app.Device, 333, CDTXMania.Skin.nScrollFieldY[ i ] + this.stBranch[ i ].nY);
+                                //    this.tx普通譜面[ 1 ].t2D描画(CDTXMania.app.Device, 333, CDTXMania.Skin.Game_Lane_Field_Y[ i ] + this.stBranch[ i ].nY);
                                 //    this.tx普通譜面[ 1 ].n透明度 = this.stBranch[ i ].ct分岐アニメ進行.n現在の値 > 100 ? 0 : ( 255 - ( ( this.stBranch[ i ].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                //    this.tx玄人譜面[ 1 ].t2D描画(CDTXMania.app.Device, 333, ( CDTXMania.Skin.nScrollFieldY[ i ] - 10 ) + this.stBranch[ i ].nY);
+                                //    this.tx玄人譜面[ 1 ].t2D描画(CDTXMania.app.Device, 333, ( CDTXMania.Skin.Game_Lane_Field_Y[ i ] - 10 ) + this.stBranch[ i ].nY);
                                 //}
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 60 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 150)
                                 {
                                     this.stBranch[i].nY = 21;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 150 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 210)
                                 {
                                     this.stBranch[i].nY = ((this.stBranch[i].ct分岐アニメ進行.n現在の値 - 150) / 2);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                 }
                             }
                             #endregion
@@ -449,12 +449,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i] + this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                 }
                             }
                             #endregion
@@ -469,12 +469,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                 }
                             }
                             #endregion
@@ -489,27 +489,27 @@ namespace TJAPlayer3
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 60));
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 60 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 150)
                                 {
                                     this.stBranch[i].nY = 21;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 150 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 210)
                                 {
                                     this.stBranch[i].nY = ((this.stBranch[i].ct分岐アニメ進行.n現在の値 - 150) / 2);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 210)
                                 {
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                 }
                             }
                             if (this.stBranch[i].nBefore == 2 && this.stBranch[i].nAfter == 1)
@@ -522,12 +522,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.nScrollFieldY[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Field_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.nScrollFieldY[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Field_Y[i]);
                                 }
 
                             }
@@ -650,12 +650,12 @@ namespace TJAPlayer3
             {
                 if (n移動方向 == 1)
                 {
-                    TJAPlayer3.Skin.nScrollFieldX[0] = this.n移動開始X + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
+                    TJAPlayer3.Skin.Game_Lane_Field_X[0] = this.n移動開始X + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
                     TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointX[0] = this.n移動開始X + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
                 }
                 else
                 {
-                    TJAPlayer3.Skin.nScrollFieldX[0] = this.n移動開始X - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
+                    TJAPlayer3.Skin.Game_Lane_Field_X[0] = this.n移動開始X - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
                     TJAPlayer3.stage演奏ドラム画面.FlyingNotes.StartPointX[0] = this.n移動開始X - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻) / (double)(this.n総移動時間)) * this.n移動距離px);
                 }
 
@@ -668,12 +668,12 @@ namespace TJAPlayer3
             {
                 if (n移動方向2 == 1)
                 {
-                    TJAPlayer3.Skin.nScrollFieldX[1] = this.n移動開始X2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
+                    TJAPlayer3.Skin.Game_Lane_Field_X[1] = this.n移動開始X2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
                     TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_X[1] = this.n移動開始X2 + (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
                 }
                 else
                 {
-                    TJAPlayer3.Skin.nScrollFieldX[1] = this.n移動開始X2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
+                    TJAPlayer3.Skin.Game_Lane_Field_X[1] = this.n移動開始X2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
                     TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_X[1] = this.n移動開始X2 - (int)((((int)CSound管理.rc演奏用タイマ.n現在時刻ms - this.n移動開始時刻2) / (double)(this.n総移動時間2)) * this.n移動距離px2);
                 }
 
@@ -764,8 +764,8 @@ namespace TJAPlayer3
             //判定枠
             if (TJAPlayer3.Tx.Notes != null)
             {
-                int nJudgeX = TJAPlayer3.Skin.nScrollFieldX[0] - (130 / 2); //元の値は349なんだけど...
-                int nJudgeY = TJAPlayer3.Skin.nScrollFieldY[0]; //元の値は349なんだけど...
+                int nJudgeX = TJAPlayer3.Skin.Game_Lane_Field_X[0] - (130 / 2); //元の値は349なんだけど...
+                int nJudgeY = TJAPlayer3.Skin.Game_Lane_Field_Y[0]; //元の値は349なんだけど...
                 TJAPlayer3.Tx.Judge_Frame.b加算合成 = TJAPlayer3.Skin.Game_JudgeFrame_AddBlend;
                 TJAPlayer3.Tx.Judge_Frame.t2D描画(TJAPlayer3.app.Device, nJudgeX, nJudgeY, new Rectangle(0, 0, 130, 130));
 
@@ -791,14 +791,14 @@ namespace TJAPlayer3
 
                         Matrix mat = Matrix.Identity;
                         mat *= Matrix.Scaling(f倍率, f倍率, 1.0f);
-                        mat *= Matrix.Translation(TJAPlayer3.Skin.nScrollFieldX[i] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.nJudgePointY[i] - SampleFramework.GameWindowSize.Height / 2.0f), 0f);
+                        mat *= Matrix.Translation(TJAPlayer3.Skin.Game_Lane_Field_X[i] - SampleFramework.GameWindowSize.Width / 2.0f, -(TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - SampleFramework.GameWindowSize.Height / 2.0f), 0f);
 
                         //this.txゴーゴー炎.b加算合成 = true;
 
                         //this.ctゴーゴー.n現在の値 = 6;
                         if (this.ctゴーゴー.b終了値に達した)
                         {
-                            TJAPlayer3.Tx.Effects_Fire.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldX[i] - 180, TJAPlayer3.Skin.nJudgePointY[i] - (TJAPlayer3.Tx.Effects_Fire.szテクスチャサイズ.Height / 2), new Rectangle(360 * (this.ctゴーゴー炎.n現在の値), 0, 360, 370));
+                            TJAPlayer3.Tx.Effects_Fire.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[i] - 180, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - (TJAPlayer3.Tx.Effects_Fire.szテクスチャサイズ.Height / 2), new Rectangle(360 * (this.ctゴーゴー炎.n現在の値), 0, 360, 370));
                         }
                         else
                         {
@@ -829,17 +829,17 @@ namespace TJAPlayer3
                             case E判定.Auto:
                                 //this.txアタックエフェクトLower.t2D描画( CDTXMania.app.Device, 285, 127, new Rectangle( this.st状態[ i ].ct進行.n現在の値 * 260, n, 260, 260 ) );
                                 if (this.st状態[i].nIsBig == 1 && TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldX[0] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.nJudgePointY[i] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Great_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Great_Big[0].szテクスチャサイズ.Width / 2);
                                 else if (TJAPlayer3.Tx.Effects_Hit_Great[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Great[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldX[0] - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.nJudgePointY[i] - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Great[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Great[0].szテクスチャサイズ.Width / 2);
                                 break;
 
                             case E判定.Good:
                                 //this.txアタックエフェクトLower.t2D描画( CDTXMania.app.Device, 285, 127, new Rectangle( this.st状態[ i ].ct進行.n現在の値 * 260, n + 260, 260, 260 ) );
                                 if (this.st状態[i].nIsBig == 1 && TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldX[0] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.nJudgePointY[i] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Good_Big[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Good_Big[0].szテクスチャサイズ.Width / 2);
                                 else if (TJAPlayer3.Tx.Effects_Hit_Good[this.st状態[i].ct進行.n現在の値] != null)
-                                    TJAPlayer3.Tx.Effects_Hit_Good[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldX[0] - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.nJudgePointY[i] - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2);
+                                    TJAPlayer3.Tx.Effects_Hit_Good[this.st状態[i].ct進行.n現在の値].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Field_X[0] - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2, TJAPlayer3.Skin.Game_Lane_JudgePoint_Y[i] - TJAPlayer3.Tx.Effects_Hit_Good[0].szテクスチャサイズ.Width / 2);
                                 break;
 
                             case E判定.Miss:
@@ -912,7 +912,7 @@ namespace TJAPlayer3
         public void t判定枠移動(double db移動時間, int n移動px, int n移動方向)
         {
             this.n移動開始時刻 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
-            this.n移動開始X = TJAPlayer3.Skin.nScrollFieldX[0];
+            this.n移動開始X = TJAPlayer3.Skin.Game_Lane_Field_X[0];
             this.n総移動時間 = (int)(db移動時間 * 1000);
             this.n移動方向 = n移動方向;
             this.n移動距離px = n移動px;
@@ -921,7 +921,7 @@ namespace TJAPlayer3
         public void t判定枠移動2(double db移動時間, int n移動px, int n移動方向)
         {
             this.n移動開始時刻2 = (int)CSound管理.rc演奏用タイマ.n現在時刻ms;
-            this.n移動開始X2 = TJAPlayer3.Skin.nScrollFieldX[1];
+            this.n移動開始X2 = TJAPlayer3.Skin.Game_Lane_Field_X[1];
             this.n総移動時間2 = (int)(db移動時間 * 1000);
             this.n移動方向2 = n移動方向;
             this.n移動距離px2 = n移動px;

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drumsレーン太鼓.cs
@@ -243,9 +243,9 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[0] != null && TJAPlayer3.Tx.Lane_Base[1] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[1].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             //普通→達人
@@ -257,8 +257,8 @@ namespace TJAPlayer3
                                 }
                                 if (TJAPlayer3.Tx.Lane_Base[0] != null && TJAPlayer3.Tx.Lane_Base[2] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -268,8 +268,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[1] != null && TJAPlayer3.Tx.Lane_Base[2] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -279,8 +279,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[1] != null && TJAPlayer3.Tx.Lane_Base[0] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -290,8 +290,8 @@ namespace TJAPlayer3
                             {
                                 if (TJAPlayer3.Tx.Lane_Base[2] != null && TJAPlayer3.Tx.Lane_Base[0] != null)
                                 {
-                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
-                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Base[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Base[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                                 }
                             }
@@ -357,15 +357,15 @@ namespace TJAPlayer3
                             {
                                 case 0:
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     break;
                                 case 1:
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     break;
                                 case 2:
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     break;
                             }
                         }
@@ -384,14 +384,14 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 30) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 30) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
 
                             }
@@ -405,9 +405,9 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 12) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 12) + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 //if( this.stBranch[ i ].ct分岐アニメ進行.n現在の値 >= 5 && this.stBranch[ i ].ct分岐アニメ進行.n現在の値 < 60 )
                                 //{
@@ -419,21 +419,21 @@ namespace TJAPlayer3
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 60 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 150)
                                 {
                                     this.stBranch[i].nY = 21;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 150 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 210)
                                 {
                                     this.stBranch[i].nY = ((this.stBranch[i].ct分岐アニメ進行.n現在の値 - 150) / 2);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             #endregion
@@ -449,12 +449,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] + this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] - 20) + this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             #endregion
@@ -469,12 +469,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             #endregion
@@ -489,27 +489,27 @@ namespace TJAPlayer3
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 60));
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 60 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 150)
                                 {
                                     this.stBranch[i].nY = 21;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 150 && this.stBranch[i].ct分岐アニメ進行.n現在の値 < 210)
                                 {
                                     this.stBranch[i].nY = ((this.stBranch[i].ct分岐アニメ進行.n現在の値 - 150) / 2);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].ct分岐アニメ進行.n現在の値 > 100 ? 0 : (255 - ((this.stBranch[i].ct分岐アニメ進行.n現在の値 * 0xff) / 100));
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else if (this.stBranch[i].ct分岐アニメ進行.n現在の値 >= 210)
                                 {
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
                             }
                             if (this.stBranch[i].nBefore == 2 && this.stBranch[i].nAfter == 1)
@@ -522,12 +522,12 @@ namespace TJAPlayer3
                                 if (this.stBranch[i].ct分岐アニメ進行.n現在の値 < 60)
                                 {
                                     this.stBranch[i].nY = this.stBranch[i].ct分岐アニメ進行.n現在の値 / 2;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i] - this.stBranch[i].nY);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], (TJAPlayer3.Skin.Game_Lane_Background_Y[i] + 30) - this.stBranch[i].nY);
                                 }
                                 else
                                 {
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], TJAPlayer3.Skin.Game_Lane_Background_Y[i]);
                                 }
 
                             }
@@ -547,15 +547,15 @@ namespace TJAPlayer3
                             {
                                 case 0:
                                     TJAPlayer3.Tx.Lane_Text[0].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, 192);
+                                    TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192);
                                     break;
                                 case 1:
                                     TJAPlayer3.Tx.Lane_Text[1].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, 192);
+                                    TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192);
                                     break;
                                 case 2:
                                     TJAPlayer3.Tx.Lane_Text[2].n透明度 = 255;
-                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, 192);
+                                    TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192);
                                     break;
                             }
                         }
@@ -567,15 +567,15 @@ namespace TJAPlayer3
                             //普通→玄人
                             if (this.stBranch[i].nBefore == 0 && this.stBranch[i].nAfter == 1)
                             {
-                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, 192 - this.stBranch[i].nY座標);
-                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, 212 - this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192 - this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 212 - this.stBranch[i].nY座標);
                                 TJAPlayer3.Tx.Lane_Text[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                             }
                             //普通→達人
                             if (this.stBranch[i].nBefore == 0 && this.stBranch[i].nAfter == 2)
                             {
-                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, 192 - this.stBranch[i].nY座標);
-                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, 212 - this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192 - this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 212 - this.stBranch[i].nY座標);
                                 TJAPlayer3.Tx.Lane_Text[0].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                             }
                             #endregion
@@ -583,30 +583,30 @@ namespace TJAPlayer3
                             //玄人→達人
                             if (this.stBranch[i].nBefore == 1 && this.stBranch[i].nAfter == 2)
                             {
-                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, 192 - this.stBranch[i].nY座標);
-                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, 212 - this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192 - this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 212 - this.stBranch[i].nY座標);
                                 TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                             }
                             #endregion
                             #region[ 玄人譜面_レベルダウン ]
                             if (this.stBranch[i].nBefore == 1 && this.stBranch[i].nAfter == 0)
                             {
-                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, 192 + this.stBranch[i].nY座標);
-                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, 168 + this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192 + this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 168 + this.stBranch[i].nY座標);
                                 TJAPlayer3.Tx.Lane_Text[1].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                             }
                             #endregion
                             #region[ 達人譜面_レベルダウン ]
                             if (this.stBranch[i].nBefore == 2 && this.stBranch[i].nAfter == 0)
                             {
-                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, 192 + this.stBranch[i].nY座標);
-                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, 333, 168 + this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192 + this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[0].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 168 + this.stBranch[i].nY座標);
                                 TJAPlayer3.Tx.Lane_Text[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                             }
                             if (this.stBranch[i].nBefore == 2 && this.stBranch[i].nAfter == 1)
                             {
-                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, 333, 192 + this.stBranch[i].nY座標);
-                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, 333, 168 + this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[2].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 192 + this.stBranch[i].nY座標);
+                                TJAPlayer3.Tx.Lane_Text[1].t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[i], 168 + this.stBranch[i].nY座標);
                                 TJAPlayer3.Tx.Lane_Text[2].n透明度 = this.stBranch[i].nBranchレイヤー透明度;
                             }
                             #endregion
@@ -620,10 +620,10 @@ namespace TJAPlayer3
 
             if (TJAPlayer3.Tx.Lane_Background_Sub != null)
             {
-                TJAPlayer3.Tx.Lane_Background_Sub.t2D描画(TJAPlayer3.app.Device, 333, 326);
+                TJAPlayer3.Tx.Lane_Background_Sub.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[0], 134 + TJAPlayer3.Skin.Game_Lane_Background_Y[0]);
                 if (TJAPlayer3.stage演奏ドラム画面.bDoublePlay)
                 {
-                    TJAPlayer3.Tx.Lane_Background_Sub.t2D描画(TJAPlayer3.app.Device, 333, 502);
+                    TJAPlayer3.Tx.Lane_Background_Sub.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[1], 134 + TJAPlayer3.Skin.Game_Lane_Background_Y[0]);
                 }
             }
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums判定文字列.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CAct演奏Drums判定文字列.cs
@@ -103,8 +103,8 @@ namespace TJAPlayer3
 					{
 						int baseX = 370;
                         //int baseY = 135;
-                        int baseY = TJAPlayer3.Skin.nScrollFieldY[base.st状態[j].nPlayer] - 53;
-						int x = TJAPlayer3.Skin.nScrollFieldX[ 0 ] - TJAPlayer3.Tx.Judge.szテクスチャサイズ.Width / 2;
+                        int baseY = TJAPlayer3.Skin.Game_Lane_Field_Y[base.st状態[j].nPlayer] - 53;
+						int x = TJAPlayer3.Skin.Game_Lane_Field_X[ 0 ] - TJAPlayer3.Tx.Judge.szテクスチャサイズ.Width / 2;
 						int y = ( baseY + base.st状態[ j ].n相対Y座標 );
 						if( TJAPlayer3.Tx.Judge != null )
 						{

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1691,32 +1691,32 @@ namespace TJAPlayer3
                     }
                 }
 
-                int x = 349 + pChip.nバーからの距離dot.Taiko + 10;
-                int x末端 = 349 + pChip.nバーからのノーツ末端距離dot.Taiko + 10;
+                int x = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + pChip.nバーからの距離dot.Taiko + 10;
+                int x末端 = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + pChip.nバーからのノーツ末端距離dot.Taiko + 10;
                 int y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ];
 
                 if( pChip.nチャンネル番号 >= 0x15 && pChip.nチャンネル番号 <= 0x17 )
                 {
                     if( pChip.nノーツ移動開始時刻ms != 0 && ( CSound管理.rc演奏用タイマ.n現在時刻ms < pChip.n発声時刻ms - pChip.nノーツ移動開始時刻ms ) )
                     {
-                        x = 349 + nノート座標;
-                        x末端 = 349 + nノート末端座標;
+                        x = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + nノート座標;
+                        x末端 = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + nノート末端座標;
                     }
                     else
                     {
-                        x = 349 + pChip.nバーからの距離dot.Taiko + 10;
-                        x末端 = 349 + pChip.nバーからのノーツ末端距離dot.Taiko + 10;
+                        x = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + pChip.nバーからの距離dot.Taiko + 10;
+                        x末端 = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + pChip.nバーからのノーツ末端距離dot.Taiko + 10;
                     }
                 }
                 else if( pChip.nチャンネル番号 == 0x18 )
                 {
                     if( pChip.nノーツ移動開始時刻ms != 0 && ( CSound管理.rc演奏用タイマ.n現在時刻ms < n先頭発声位置 - pChip.nノーツ移動開始時刻ms ) )
                     {
-                        x = 349 + nノート座標;
+                        x = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + nノート座標;
                     }
                     else
                     {
-                        x = 349 + pChip.nバーからの距離dot.Taiko + 10;
+                        x = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2) + pChip.nバーからの距離dot.Taiko + 10;
                     }
                 }
 
@@ -1927,7 +1927,7 @@ namespace TJAPlayer3
                         if( pChip.nチャンネル番号 == 0x17 )
                         {
                             if( pChip.n発声時刻ms < CSound管理.rc演奏用タイマ.n現在時刻ms && pChip.nノーツ終了時刻ms > CSound管理.rc演奏用タイマ.n現在時刻ms )
-                                x = 349;
+                                x = TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - (130 / 2);
                             if( TJAPlayer3.ConfigIni.eSTEALTH != Eステルスモード.DORON )
                                 TJAPlayer3.Tx.Notes.t2D描画( TJAPlayer3.app.Device, x, y, new Rectangle( 1430, num9, 260, 130 ) );
 
@@ -1999,7 +1999,7 @@ namespace TJAPlayer3
             if( pChip.dbSCROLL_Y != 0.0 )
             {
                 y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ];
-                y += (int) ( ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL_Y * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
+                y += (int) ( ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL_Y * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1 )) / 502.8594);
             }
 
 			if ( !pChip.bHit && pChip.n発声時刻ms > CSound管理.rc演奏用タイマ.n現在時刻 )

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -2016,7 +2016,7 @@ namespace TJAPlayer3
 			{
                 int n小節番号 = this.actPlayInfo.n小節番号;
                 //int n小節番号 = pChip.n整数値;
-                   if( x >= 310 )
+                   if( x >= TJAPlayer3.Skin.Game_Lane_Field_X[nPlayer] - 104)
 				    TJAPlayer3.act文字コンソール.tPrint( x + 8, y - 26, C文字コンソール.Eフォント種別.白, n小節番号.ToString() );
 				    //CDTXMania.act文字コンソール.tPrint( x + 8, y - 10, C文字コンソール.Eフォント種別.白, pChip.dbBPM.ToString() );
 			}

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1427,6 +1427,7 @@ namespace TJAPlayer3
                     }
                     #endregion
 
+
                     if( pChip.dbSCROLL_Y != 0.0 )
                     {
                         y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ];

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -1358,7 +1358,7 @@ namespace TJAPlayer3
                     }
 
                     int x = 0;
-                    int y = TJAPlayer3.Skin.nScrollFieldY[nPlayer];
+                    int y = TJAPlayer3.Skin.Game_Lane_Field_Y[nPlayer];
 
                     if ( pChip.nノーツ移動開始時刻ms != 0 && ( nPlayTime < pChip.n発声時刻ms - pChip.nノーツ移動開始時刻ms ) )
                     {
@@ -1381,34 +1381,34 @@ namespace TJAPlayer3
                     switch ( pChip.nスクロール方向 )
                     {
                         case 0:
-                            x += ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] );
+                            x += ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] );
                             break;
                         case 1:
-                            x = ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] );
-                            y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ] - xTemp;
+                            x = ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] );
+                            y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ] - xTemp;
                             break;
                         case 2:
-                            x = ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] + 3 );
-                            y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ] + xTemp;
+                            x = ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] + 3 );
+                            y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ] + xTemp;
                             break;
                         case 3:
-                            x += ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] );
-                            y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ] - xTemp;
+                            x += ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] );
+                            y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ] - xTemp;
                             break;
                         case 4:
-                            x += ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] );
-                            y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ] + xTemp;
+                            x += ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] );
+                            y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ] + xTemp;
                             break;
                         case 5:
-                            x = ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] + 10 ) - xTemp;
+                            x = ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] + 10 ) - xTemp;
                             break;
                         case 6:
-                            x = ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] ) - xTemp;
-                            y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ] - xTemp;
+                            x = ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] ) - xTemp;
+                            y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ] - xTemp;
                             break;
                         case 7:
-                            x = ( TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] ) - xTemp;
-                            y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ] + xTemp;
+                            x = ( TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] ) - xTemp;
+                            y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ] + xTemp;
                             break;
                     }
                     #endregion
@@ -1416,7 +1416,7 @@ namespace TJAPlayer3
                     #region[ 両手待ち時 ]
                     if( pChip.eNoteState == ENoteState.wait )
                     {
-                        x = ( TJAPlayer3.Skin.nScrollFieldX[0] );
+                        x = ( TJAPlayer3.Skin.Game_Lane_Field_X[0] );
                     }
                     #endregion
 
@@ -1429,7 +1429,7 @@ namespace TJAPlayer3
 
                     if( pChip.dbSCROLL_Y != 0.0 )
                     {
-                        y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ];
+                        y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ];
                         if( TJAPlayer3.ConfigIni.eScrollMode == EScrollMode.Normal )
                             y += (int) ( ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL_Y * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1 ) ) / 502.8594 );
                         else if( TJAPlayer3.ConfigIni.eScrollMode == EScrollMode.BMSCROLL || TJAPlayer3.ConfigIni.eScrollMode == EScrollMode.HBSCROLL )
@@ -1693,7 +1693,7 @@ namespace TJAPlayer3
 
                 int x = 349 + pChip.nバーからの距離dot.Taiko + 10;
                 int x末端 = 349 + pChip.nバーからのノーツ末端距離dot.Taiko + 10;
-                int y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ];
+                int y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ];
 
                 if( pChip.nチャンネル番号 >= 0x15 && pChip.nチャンネル番号 <= 0x17 )
                 {
@@ -1993,12 +1993,12 @@ namespace TJAPlayer3
 
 			//int n小節番号plus1 = pChip.n発声位置 / 384;
             int n小節番号plus1 = this.actPlayInfo.n小節番号;
-            int x = TJAPlayer3.Skin.nScrollFieldX[ nPlayer ] + pChip.nバーからの距離dot.Taiko;
-            int y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ];
+            int x = TJAPlayer3.Skin.Game_Lane_Field_X[ nPlayer ] + pChip.nバーからの距離dot.Taiko;
+            int y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ];
 
             if( pChip.dbSCROLL_Y != 0.0 )
             {
-                y = TJAPlayer3.Skin.nScrollFieldY[ nPlayer ];
+                y = TJAPlayer3.Skin.Game_Lane_Field_Y[ nPlayer ];
                 y += (int) ( ( ( pChip.n発声時刻ms - CSound管理.rc演奏用タイマ.n現在時刻 ) * pChip.dbBPM * pChip.dbSCROLL_Y * ( this.act譜面スクロール速度.db現在の譜面スクロール速度.Drums + 1.5 ) ) / 628.7 );
             }
 

--- a/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/CStage演奏ドラム画面.cs
@@ -2031,12 +2031,12 @@ namespace TJAPlayer3
                     if( pChip.bBranch )
                     {
                         //this.tx小節線_branch.t2D描画( CDTXMania.app.Device, x - 3, y, new Rectangle( 0, 0, 3, 130 ) );
-                        TJAPlayer3.Tx.Bar_Branch.t3D描画( TJAPlayer3.app.Device, mat, new Rectangle( 0, 0, 3, 130 ) );
+                        TJAPlayer3.Tx.Bar_Branch.t3D描画( TJAPlayer3.app.Device, mat, new Rectangle( 0, 0, TJAPlayer3.Skin.Game_Bar_Width, TJAPlayer3.Skin.Game_Bar_Height ) );
                     }
                     else
                     {
                         //this.tx小節線.t2D描画( CDTXMania.app.Device, x - 3, y, new Rectangle( 0, 0, 3, 130 ) );
-                        TJAPlayer3.Tx.Bar.t3D描画( TJAPlayer3.app.Device, mat, new Rectangle( 0, 0, 3, 130 ) );
+                        TJAPlayer3.Tx.Bar.t3D描画( TJAPlayer3.app.Device, mat, new Rectangle( 0, 0, TJAPlayer3.Skin.Game_Bar_Width, TJAPlayer3.Skin.Game_Bar_Height) );
                     }
                 }
 			}

--- a/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
@@ -320,8 +320,8 @@ namespace TJAPlayer3
                         ScreenPoint[1] += ((1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2) - ScreenPoint[1]) / 180.0;
                     }
                     Counter_In_Old = Counter_In.n現在の値;
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.Game_Lane_Background_Y[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.Game_Lane_Background_Y[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
                     //CDTXMania.act文字コンソール.tPrint(0, 420, C文字コンソール.Eフォント種別.白, String.Format("{0} : {1}", ScreenPoint[0], ScreenPoint[1]));
                 }
                 if (Counter_In.b終了値に達した)
@@ -334,7 +334,7 @@ namespace TJAPlayer3
             {
                 if (Counter_Wait.b終了値に達してない)
                 {
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[0], TJAPlayer3.Skin.Game_Lane_Field_Y[0]);
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[0], TJAPlayer3.Skin.Game_Lane_Background_Y[0]);
                 }
                 if (Counter_Wait.b終了値に達した)
                 {
@@ -348,11 +348,11 @@ namespace TJAPlayer3
                 if (Counter_Text.b終了値に達してない)
                 {
                     if (TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].SubTitleTex == null)
-                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[0] + 65);
+                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Background_Y[0] + 65);
                     else
                     {
-                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[0] + 45);
-                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].SubTitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[0] + 85);
+                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Background_Y[0] + 45);
+                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].SubTitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Background_Y[0] + 85);
                     }
                 }
                 if (Counter_Text.b終了値に達した)
@@ -371,8 +371,8 @@ namespace TJAPlayer3
                         ScreenPoint[1] += 3;
                     }
                     Counter_Out_Old = Counter_Out.n現在の値;
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.Game_Lane_Background_Y[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.Game_Lane_Background_Y[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
                     //CDTXMania.act文字コンソール.tPrint(0, 420, C文字コンソール.Eフォント種別.白, String.Format("{0} : {1}", ScreenPoint[0], ScreenPoint[1]));
                 }
                 if (Counter_Out.b終了値に達した)

--- a/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/Dan_Cert.cs
@@ -27,7 +27,7 @@ namespace TJAPlayer3
         {
             NowShowingNumber = number;
             Counter_In = new CCounter(0, 999, 1, TJAPlayer3.Timer);
-            ScreenPoint = new double[] { TJAPlayer3.Skin.nScrollFieldBGX[0] - TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 1280 };
+            ScreenPoint = new double[] { TJAPlayer3.Skin.Game_Lane_Background_X[0] - TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 1280 };
             TJAPlayer3.stage演奏ドラム画面.ReSetScore(TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].ScoreInit, TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].ScoreDiff);
             IsAnimating = true;
             TJAPlayer3.stage演奏ドラム画面.actPanel.SetPanelString(TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].Title, TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].Genre, 1 + NowShowingNumber + "曲目");
@@ -316,12 +316,12 @@ namespace TJAPlayer3
                 {
                     for (int i = Counter_In_Old; i < Counter_In.n現在の値; i++)
                     {
-                        ScreenPoint[0] += (TJAPlayer3.Skin.nScrollFieldBGX[0] - ScreenPoint[0]) / 180.0;
-                        ScreenPoint[1] += ((1280 / 2 + TJAPlayer3.Skin.nScrollFieldBGX[0] / 2) - ScreenPoint[1]) / 180.0;
+                        ScreenPoint[0] += (TJAPlayer3.Skin.Game_Lane_Background_X[0] - ScreenPoint[0]) / 180.0;
+                        ScreenPoint[1] += ((1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2) - ScreenPoint[1]) / 180.0;
                     }
                     Counter_In_Old = Counter_In.n現在の値;
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.nScrollFieldY[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.nScrollFieldY[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
                     //CDTXMania.act文字コンソール.tPrint(0, 420, C文字コンソール.Eフォント種別.白, String.Format("{0} : {1}", ScreenPoint[0], ScreenPoint[1]));
                 }
                 if (Counter_In.b終了値に達した)
@@ -334,7 +334,7 @@ namespace TJAPlayer3
             {
                 if (Counter_Wait.b終了値に達してない)
                 {
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[0], TJAPlayer3.Skin.nScrollFieldY[0]);
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[0], TJAPlayer3.Skin.Game_Lane_Field_Y[0]);
                 }
                 if (Counter_Wait.b終了値に達した)
                 {
@@ -348,11 +348,11 @@ namespace TJAPlayer3
                 if (Counter_Text.b終了値に達してない)
                 {
                     if (TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].SubTitleTex == null)
-                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.nScrollFieldBGX[0] / 2, TJAPlayer3.Skin.nScrollFieldY[0] + 65);
+                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[0] + 65);
                     else
                     {
-                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.nScrollFieldBGX[0] / 2, TJAPlayer3.Skin.nScrollFieldY[0] + 45);
-                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].SubTitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.nScrollFieldBGX[0] / 2, TJAPlayer3.Skin.nScrollFieldY[0] + 85);
+                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].TitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[0] + 45);
+                        TJAPlayer3.DTX.List_DanSongs[NowShowingNumber].SubTitleTex?.t2D中心基準描画(TJAPlayer3.app.Device, 1280 / 2 + TJAPlayer3.Skin.Game_Lane_Background_X[0] / 2, TJAPlayer3.Skin.Game_Lane_Field_Y[0] + 85);
                     }
                 }
                 if (Counter_Text.b終了値に達した)
@@ -371,8 +371,8 @@ namespace TJAPlayer3
                         ScreenPoint[1] += 3;
                     }
                     Counter_Out_Old = Counter_Out.n現在の値;
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.nScrollFieldY[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
-                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.nScrollFieldY[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[0], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(0, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
+                    TJAPlayer3.Tx.DanC_Screen?.t2D描画(TJAPlayer3.app.Device, (int)ScreenPoint[1], TJAPlayer3.Skin.Game_Lane_Field_Y[0], new Rectangle(TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, 0, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Width / 2, TJAPlayer3.Tx.DanC_Screen.szテクスチャサイズ.Height));
                     //CDTXMania.act文字コンソール.tPrint(0, 420, C文字コンソール.Eフォント種別.白, String.Format("{0} : {1}", ScreenPoint[0], ScreenPoint[1]));
                 }
                 if (Counter_Out.b終了値に達した)

--- a/TJAPlayer3/Stages/07.Game/Taiko/FlyingNotes.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/FlyingNotes.cs
@@ -32,13 +32,13 @@ namespace TJAPlayer3
                         Flying[i].Lane = nLane;
                         Flying[i].Player = nPlayer;
                         Flying[i].X = StartPointX[nPlayer];
-                        Flying[i].Y = TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_Y[nPlayer];
+                        Flying[i].Y = StartPointY[nPlayer];
                         Flying[i].StartPointX = StartPointX[nPlayer];
-                        Flying[i].StartPointY = TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_Y[nPlayer];
+                        Flying[i].StartPointY = StartPointY[nPlayer];
                         Flying[i].OldValue = 0;
                         Flying[i].IsRoll = isRoll;
                         // 角度の決定
-                        Flying[i].Height = Math.Abs(TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[nPlayer] - TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_Y[nPlayer]);
+                        Flying[i].Height = Math.Abs(TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[nPlayer] - StartPointY[nPlayer]);
                         Flying[i].Width = Math.Abs((TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[nPlayer] - StartPointX[nPlayer])) / 2;
                         //Console.WriteLine("{0}, {1}", width2P, height2P);
                         Flying[i].Theta = ((Math.Atan2(Flying[i].Height, Flying[i].Width) * 180.0) / Math.PI);
@@ -46,7 +46,7 @@ namespace TJAPlayer3
                         //Flying[i].Counter = new CCounter(0, 200000, CDTXMania.Skin.Game_Effect_FlyingNotes_Timer, CDTXMania.Timer);
 
                         Flying[i].IncreaseX = (1.00 * Math.Abs((TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_X[nPlayer] - StartPointX[nPlayer]))) / (180);
-                        Flying[i].IncreaseY = (1.00 * Math.Abs((TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[nPlayer] - TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_Y[nPlayer]))) / (180);
+                        Flying[i].IncreaseY = (1.00 * Math.Abs((TJAPlayer3.Skin.Game_Effect_FlyingNotes_EndPoint_Y[nPlayer] - StartPointY[nPlayer]))) / (180);
                         break;
                     }
                 }
@@ -66,6 +66,10 @@ namespace TJAPlayer3
             for (int i = 0; i < 2; i++)
             {
                 StartPointX[i] = TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_X[i];
+            }
+            for (int i = 0; i < 2; i++)
+            {
+                StartPointY[i] = TJAPlayer3.Skin.Game_Effect_FlyingNotes_StartPoint_Y[i];
             }
             base.On活性化();
 		}
@@ -186,6 +190,7 @@ namespace TJAPlayer3
         private Status[] Flying = new Status[128];
 
         public readonly int[] StartPointX = new int[2];
+        public readonly int[] StartPointY = new int[2];
 
         //-----------------
         #endregion

--- a/TJAPlayer3/Stages/07.Game/Taiko/LaneFlash.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/LaneFlash.cs
@@ -46,7 +46,7 @@ namespace TJAPlayer3
                 if (Counter.b終了値に達した) Counter.t停止();
                 int opacity = (((150 - Counter.n現在の値) * 255) / 100);
                 Texture.n透明度 = opacity;
-                Texture.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.nScrollFieldBGX[Player], TJAPlayer3.Skin.nScrollFieldY[Player]);
+                Texture.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[Player], TJAPlayer3.Skin.Game_Lane_Field_Y[Player]);
             }
             return base.On進行描画();
         }

--- a/TJAPlayer3/Stages/07.Game/Taiko/LaneFlash.cs
+++ b/TJAPlayer3/Stages/07.Game/Taiko/LaneFlash.cs
@@ -46,7 +46,7 @@ namespace TJAPlayer3
                 if (Counter.b終了値に達した) Counter.t停止();
                 int opacity = (((150 - Counter.n現在の値) * 255) / 100);
                 Texture.n透明度 = opacity;
-                Texture.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[Player], TJAPlayer3.Skin.Game_Lane_Field_Y[Player]);
+                Texture.t2D描画(TJAPlayer3.app.Device, TJAPlayer3.Skin.Game_Lane_Background_X[Player], TJAPlayer3.Skin.Game_Lane_Background_Y[Player]);
             }
             return base.On進行描画();
         }


### PR DESCRIPTION
以下の変更を含みます。
・小節線の描画範囲を自由化
・レーンのフィールド、判定枠、mTaikoの背景のやつの座標を自由化
・↑に伴って、いくつかの変数名をSkinConfigの他項目名に合わせて名称変更
・JPOSSCROLLの上下移動を可能に
・↑に伴って、いくつかのSkinConfig項目の整理
・ゲージ座標の自由化（Gauge_Base、Gauge_nP、Rainbow、Soul関連あたりは連動するように）