### PR TITLE
DP時、ComboVoieが特定状況下で正常に発声しなくなるのを修正

### DIFF
--- a/TJAPlayer3/Stages/07.Game/CAct演奏Combo音声.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏Combo音声.cs
@@ -37,12 +37,9 @@ namespace TJAPlayer3
         /// カーソルを戻す。
         /// コンボが切れた時に使う。
         /// </summary>
-        public void tリセット()
+        public void tReset(int nPlayer)
         {
-            for (int i = 0; i < 2; i++)
-            {
-                VoiceIndex[i] = 0;
-            }
+            VoiceIndex[nPlayer] = 0;
         }
 
 		// CActivity 実装

--- a/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CStage演奏画面共通.cs
@@ -1635,7 +1635,7 @@ namespace TJAPlayer3
                                     this.nBranch_Miss[ nPlayer ]++;
                                     if( nPlayer == 0 ) this.nヒット数_Auto含まない.Drums.Miss++;
                                     this.actCombo.n現在のコンボ数[ nPlayer ] = 0;
-                                    this.actComboVoice.tリセット();
+                                    this.actComboVoice.tReset(nPlayer);
                                     //for (int i = 0; i < 2; i++)
                                     //{
                                     //    ctChipAnime[i].t停止();
@@ -1679,7 +1679,7 @@ namespace TJAPlayer3
                                     {
                                         this.nBranch_Miss[ nPlayer ]++;
 								        this.actCombo.n現在のコンボ数[ nPlayer ] = 0;
-                                        this.actComboVoice.tリセット();
+                                        this.actComboVoice.tReset(nPlayer);
                                         //for (int i = 0; i < 2; i++)
                                         //{
                                         //    ctChipAnime[i].t停止();
@@ -4088,8 +4088,8 @@ namespace TJAPlayer3
                     this.n合計連打数[ i ] = 0;
                     this.n分岐した回数[ i ] = 0;
                 }
-
-                this.actComboVoice.tリセット();
+                for (int i = 0; i < 2; i++)
+                    this.actComboVoice.tReset(i);
             }
 
             this.ReSetScore(TJAPlayer3.DTX.nScoreInit[0, TJAPlayer3.stage選曲.n確定された曲の難易度], TJAPlayer3.DTX.nScoreDiff[TJAPlayer3.stage選曲.n確定された曲の難易度]);


### PR DESCRIPTION
"tリセット"を"tReset"に名称変更
VoiceIndexのリセットをnPlayerを参照して行うようにした