### PR TITLE
選曲画面での曲読み込み時に、読み込んだTJAの文字列によってScrollModeが勝手に切り替わってしまっているっぽいのを修正

### DIFF
--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -1022,6 +1022,7 @@ namespace TJAPlayer3
                                     SongSelect_Auto_Y[i] = int.Parse(strSplit[i]);
                                 }
                             }
+
                             else if (strCommand == "SongSelect_ForeColor_JPOP")
                             {
                                 SongSelect_ForeColor_JPOP = ColorTranslator.FromHtml(strParam);
@@ -1054,6 +1055,7 @@ namespace TJAPlayer3
                             {
                                 SongSelect_ForeColor_Namco = ColorTranslator.FromHtml(strParam);
                             }
+
                             else if (strCommand == "SongSelect_BackColor_JPOP")
                             {
                                 SongSelect_BackColor_JPOP = ColorTranslator.FromHtml(strParam);
@@ -1086,6 +1088,26 @@ namespace TJAPlayer3
                             {
                                 SongSelect_BackColor_Namco = ColorTranslator.FromHtml(strParam);
                             }
+
+                            else if (strCommand == nameof(SongSelect_ForeColor))    //ジャンルなしの時の色
+                            {
+                                SongSelect_ForeColor = ColorTranslator.FromHtml(strParam);
+                            }
+                            else if (strCommand == nameof(SongSelect_BackColor))    //ジャンルなしの時の色
+                            {
+                                SongSelect_BackColor = ColorTranslator.FromHtml(strParam);
+                            }
+
+                            else if (strCommand == nameof(SongSelect_NowSelect_ForeColor))    //今選択している曲の色
+                            {
+                                SongSelect_NowSelect_ForeColor = ColorTranslator.FromHtml(strParam);
+                            }
+                            else if (strCommand == nameof(SongSelect_NowSelect_BackColor))    //今選択している曲の色
+                            {
+                                SongSelect_NowSelect_BackColor = ColorTranslator.FromHtml(strParam);
+                            }
+
+
                             else if (strCommand == nameof(SongSelect_CorrectionX_Chara))
                             {
                                 SongSelect_CorrectionX_Chara = strParam.Split(',').ToArray();
@@ -2438,6 +2460,12 @@ namespace TJAPlayer3
         public Color SongSelect_BackColor_Classic = ColorTranslator.FromHtml("#875600");
         public Color SongSelect_BackColor_GameMusic = ColorTranslator.FromHtml("#412080");
         public Color SongSelect_BackColor_Namco = ColorTranslator.FromHtml("#980E00");
+
+        public Color SongSelect_ForeColor = ColorTranslator.FromHtml("#FFFFFF");              //ジャンルなしの時の色
+        public Color SongSelect_BackColor = ColorTranslator.FromHtml("#000000");              //ジャンルなしの時の色
+        public Color SongSelect_NowSelect_ForeColor = ColorTranslator.FromHtml("#FFFFFF");    //今選択している曲の色
+        public Color SongSelect_NowSelect_BackColor = ColorTranslator.FromHtml("#000000");    //今選択している曲の色
+
         public string[] SongSelect_CorrectionX_Chara = { "ここにX座標を補正したい文字をカンマで区切って記入" };
         public string[] SongSelect_CorrectionY_Chara = { "ここにY座標を補正したい文字をカンマで区切って記入" };
         public int[] SongSelect_CorrectionX_Chara_Value = new int[] { 0 };

--- a/TJAPlayer3/Common/CSkin.cs
+++ b/TJAPlayer3/Common/CSkin.cs
@@ -1052,7 +1052,7 @@ namespace TJAPlayer3
                             }
                             else if (strCommand == nameof(SongSelect_ForeColor_Namco))
                             {
-                                SongSelect_ForeColor_GameMusic = ColorTranslator.FromHtml(strParam);
+                                SongSelect_ForeColor_Namco = ColorTranslator.FromHtml(strParam);
                             }
                             else if (strCommand == "SongSelect_BackColor_JPOP")
                             {

--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -4218,15 +4218,17 @@ namespace TJAPlayer3
         /// <param name="InputText"></param>
         private void t難易度別ヘッダ(string InputText)
         {
-            if (InputText.Equals("#HBSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
+            if (TJAPlayer3.actEnumSongs.b活性化してない)
             {
-                TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.HBSCROLL;
+                if (InputText.Equals("#HBSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
+                {
+                    TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.HBSCROLL;
+                }
+                if (InputText.Equals("#BMSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
+                {
+                    TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.BMSCROLL;
+                }
             }
-            if (InputText.Equals("#BMSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
-            {
-                TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.BMSCROLL;
-            }
-
 
             string[] strArray = InputText.Split(new char[] { ':' });
             string strCommandName = "";

--- a/TJAPlayer3/Songs/C曲リストノード.cs
+++ b/TJAPlayer3/Songs/C曲リストノード.cs
@@ -35,8 +35,8 @@ namespace TJAPlayer3
 			}
 		}
 		public Color col文字色 = Color.White;
-        public Color ForeColor = Color.White;
-        public Color BackColor = Color.Black;
+        public Color ForeColor = TJAPlayer3.Skin.SongSelect_ForeColor;
+        public Color BackColor = TJAPlayer3.Skin.SongSelect_BackColor;
         public bool IsChangedForeColor;
         public bool IsChangedBackColor;
 		public List<C曲リストノード> listランダム用ノードリスト;

--- a/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
+++ b/TJAPlayer3/Stages/05.SongSelect/CActSelect曲リスト.cs
@@ -1202,7 +1202,7 @@ namespace TJAPlayer3
 							#region [ タイトル名テクスチャを描画。]
 							//-----------------
                             if( this.stバー情報[ nパネル番号 ].strタイトル文字列 != "" && this.stバー情報[ nパネル番号 ].strタイトル文字列 != null && this.ttk選択している曲の曲名 == null )
-                                this.ttk選択している曲の曲名 = this.ttk曲名テクスチャを生成する( this.stバー情報[ nパネル番号 ].strタイトル文字列, Color.White, Color.Black);
+                                this.ttk選択している曲の曲名 = this.ttk曲名テクスチャを生成する( this.stバー情報[ nパネル番号 ].strタイトル文字列, TJAPlayer3.Skin.SongSelect_NowSelect_ForeColor, TJAPlayer3.Skin.SongSelect_NowSelect_BackColor);
                             if( this.stバー情報[ nパネル番号 ].strサブタイトル != "" && this.stバー情報[ nパネル番号 ].strサブタイトル != null && this.ttk選択している曲のサブタイトル == null )
                                 this.ttk選択している曲のサブタイトル = this.ttkサブタイトルテクスチャを生成する( this.stバー情報[ nパネル番号 ].strサブタイトル );
 
@@ -1495,7 +1495,7 @@ namespace TJAPlayer3
                         #region [ タイトル名テクスチャを描画。]
                         //-----------------
                         if (this.stバー情報[nパネル番号].strタイトル文字列 != "" &&  this.ttk選択している曲の曲名 == null)
-                            this.ttk選択している曲の曲名 = this.ttk曲名テクスチャを生成する(this.stバー情報[nパネル番号].strタイトル文字列, Color.White, Color.Black);
+                            this.ttk選択している曲の曲名 = this.ttk曲名テクスチャを生成する(this.stバー情報[nパネル番号].strタイトル文字列, TJAPlayer3.Skin.SongSelect_NowSelect_ForeColor, TJAPlayer3.Skin.SongSelect_NowSelect_BackColor);
                         if ( this.stバー情報[ nパネル番号 ].strサブタイトル != "" && this.ttk選択している曲のサブタイトル == null )
                             this.ttk選択している曲のサブタイトル = this.ttkサブタイトルテクスチャを生成する( this.stバー情報[ nパネル番号 ].strサブタイトル );
 
@@ -1951,7 +1951,7 @@ namespace TJAPlayer3
 
 	    private TitleTextureKey ttkサブタイトルテクスチャを生成する( string str文字 )
         {
-            return new TitleTextureKey(str文字, pfSubtitle, Color.White, Color.Black, 390);
+            return new TitleTextureKey(str文字, pfSubtitle, TJAPlayer3.Skin.SongSelect_NowSelect_ForeColor, TJAPlayer3.Skin.SongSelect_NowSelect_BackColor, 390);
         }
 
 	    private CTexture ResolveTitleTexture(TitleTextureKey titleTextureKey)


### PR DESCRIPTION
Issue#63 ( https://github.com/AioiLight/TJAPlayer3/issues/63 ) で言及していた現象についてです。
選曲画面にいる時、曲リスト生成中に勝手にScrollModeが切り替わってしまうなら、tjaからのScrollModeの切り替えを曲リスト生成中はやらないようにすればいいじゃないか、というちょっと強引な解決です。
一応ちゃんとtja内にBMSCROLLやHBSCROLLが含まれる譜面は切り替わるし、
F6で自分で切り替えたScrollModeもその次の曲で反映されます。
「曲リスト生成中」と表示されている時にHBSCROLLが含まれる譜面を選択した場合もHBSCROLLが反映されます。
副作用は特にないと思われます。