### PR TITLE
BPMが負の値のときのフリーズを回避（とりあえず）

### DIFF
--- a/FDK19/コード/00.共通/CCounter.cs
+++ b/FDK19/コード/00.共通/CCounter.cs
@@ -159,6 +159,8 @@ namespace FDK
 			this.timer = timer;
 			this.n現在の経過時間ms = this.timer.n現在時刻;
 			this.n現在の値 = n開始値;
+            if (n間隔ms <= 0)
+                n間隔ms = -n間隔ms;
 		}
 
         /// <summary>
@@ -176,6 +178,8 @@ namespace FDK
 			this.timerdb = timer;
 			this.db現在の経過時間 = this.timerdb.dbシステム時刻;
 			this.db現在の値 = db開始値;
+            if (db間隔 <= 0)
+                db間隔 = -db間隔;
 		}
 
 		/// <summary>
@@ -189,6 +193,8 @@ namespace FDK
 				long num = this.timer.n現在時刻;
 				if ( num < this.n現在の経過時間ms )
 					this.n現在の経過時間ms = num;
+                if (this.n間隔ms <= 0)
+                    this.n間隔ms = -this.n間隔ms;
 
 				while ( ( num - this.n現在の経過時間ms ) >= this.n間隔ms )
 				{
@@ -211,6 +217,8 @@ namespace FDK
 				double num = this.timerdb.n現在時刻;
 				if ( num < this.db現在の経過時間 )
 					this.db現在の経過時間 = num;
+                if (this.db間隔 <= 0)
+                    this.db間隔 = -this.db間隔;
 
 				while ( ( num - this.db現在の経過時間 ) >= this.db間隔 )
 				{
@@ -233,6 +241,8 @@ namespace FDK
 				long num = this.timer.n現在時刻;
 				if ( num < this.n現在の経過時間ms )
 					this.n現在の経過時間ms = num;
+                if (this.n間隔ms <= 0)
+                    this.n間隔ms = -this.n間隔ms;
 
 				while ( ( num - this.n現在の経過時間ms ) >= this.n間隔ms )
 				{
@@ -255,6 +265,8 @@ namespace FDK
 				double num = this.timerdb.n現在時刻;
 				if ( num < this.n現在の経過時間ms )
 					this.db現在の経過時間 = num;
+                if (this.db間隔 <= 0)
+                    this.db間隔 = -this.db間隔;
 
 				while ( ( num - this.db現在の経過時間 ) >= this.db間隔 )
 				{

--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -4218,15 +4218,17 @@ namespace TJAPlayer3
         /// <param name="InputText"></param>
         private void t難易度別ヘッダ(string InputText)
         {
-            if (InputText.Equals("#HBSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
+            if (TJAPlayer3.actEnumSongs.b活性化してない)
             {
-                TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.HBSCROLL;
+                if (InputText.Equals("#HBSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
+                {
+                    TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.HBSCROLL;
+                }
+                if (InputText.Equals("#BMSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
+                {
+                    TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.BMSCROLL;
+                }
             }
-            if (InputText.Equals("#BMSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
-            {
-                TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.BMSCROLL;
-            }
-
 
             string[] strArray = InputText.Split(new char[] { ':' });
             string strCommandName = "";

--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -4218,17 +4218,15 @@ namespace TJAPlayer3
         /// <param name="InputText"></param>
         private void t難易度別ヘッダ(string InputText)
         {
-            if (TJAPlayer3.actEnumSongs.b活性化してない)
+            if (InputText.Equals("#HBSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
             {
-                if (InputText.Equals("#HBSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
-                {
-                    TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.HBSCROLL;
-                }
-                if (InputText.Equals("#BMSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
-                {
-                    TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.BMSCROLL;
-                }
+                TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.HBSCROLL;
             }
+            if (InputText.Equals("#BMSCROLL") && TJAPlayer3.ConfigIni.bスクロールモードを上書き == false)
+            {
+                TJAPlayer3.ConfigIni.eScrollMode = EScrollMode.BMSCROLL;
+            }
+
 
             string[] strArray = InputText.Split(new char[] { ':' });
             string strCommandName = "";


### PR DESCRIPTION
メチャクチャ適当ではありますが、一応ちゃんと譜面は逆行するので実用性はあるかと思います。
カウンターの更新間隔が負の時にフリーズするので、それを塞いだだけです。