### PR TITLE
Gauge increase modes

### DIFF
--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -1281,6 +1281,7 @@ namespace TJAPlayer3
 
         public bool IsEnabledFixSENote;
         public int FixSENote;
+        public GaugeIncreaseMode GaugeIncreaseMode;
 
 
 
@@ -4783,6 +4784,33 @@ namespace TJAPlayer3
                 if (!string.IsNullOrEmpty(strCommandParam))
                 {
                     this.bHIDDENBRANCH = true;
+                }
+            }
+            else if (strCommandName.Equals("GAUGEINCR"))
+            {
+                if(!string.IsNullOrEmpty(strCommandParam))
+                {
+                    switch (strCommandParam)
+                    {
+                        case "normal":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Normal;
+                            break;
+                        case "floor":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Floor;
+                            break;
+                        case "round":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Round;
+                            break;
+                        case "ceiling":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Ceiling;
+                            break;
+                        case "notfix":
+                            GaugeIncreaseMode = GaugeIncreaseMode.NotFix;
+                            break;
+                        default:
+                            GaugeIncreaseMode = GaugeIncreaseMode.Normal;
+                            break;
+                    }
                 }
             }
             if (this.nScoreModeTmp == 99)

--- a/TJAPlayer3/Songs/CDTX.cs
+++ b/TJAPlayer3/Songs/CDTX.cs
@@ -1390,6 +1390,8 @@ namespace TJAPlayer3
             this.SongVol = CSound.DefaultSongVol;
             this.SongLoudnessMetadata = null;
 
+            GaugeIncreaseMode = GaugeIncreaseMode.Normal;
+
 #if TEST_NOTEOFFMODE
 			this.bHH演奏で直前のHHを消音する = true;
 			this.bGUITAR演奏で直前のGUITARを消音する = true;
@@ -2949,7 +2951,7 @@ namespace TJAPlayer3
 
         private static readonly Regex regexForPrefixingCommaStartingLinesWithZero = new Regex(@"^,", RegexOptions.Multiline | RegexOptions.Compiled);
         private static readonly Regex regexForStrippingHeadingLines = new Regex(
-            @"^(?!(TITLE|LEVEL|BPM|WAVE|OFFSET|BALLOON|EXAM1|EXAM2|EXAM3|BALLOONNOR|BALLOONEXP|BALLOONMAS|SONGVOL|SEVOL|SCOREINIT|SCOREDIFF|COURSE|STYLE|GAME|LIFE|DEMOSTART|SIDE|SUBTITLE|SCOREMODE|GENRE|MOVIEOFFSET|BGIMAGE|BGMOVIE|HIDDENBRANCH|#HBSCROLL|#BMSCROLL)).+\n",
+            @"^(?!(TITLE|LEVEL|BPM|WAVE|OFFSET|BALLOON|EXAM1|EXAM2|EXAM3|BALLOONNOR|BALLOONEXP|BALLOONMAS|SONGVOL|SEVOL|SCOREINIT|SCOREDIFF|COURSE|STYLE|GAME|LIFE|DEMOSTART|SIDE|SUBTITLE|SCOREMODE|GENRE|MOVIEOFFSET|BGIMAGE|BGMOVIE|HIDDENBRANCH|GAUGEINCR|#HBSCROLL|#BMSCROLL)).+\n",
             RegexOptions.Multiline | RegexOptions.Compiled);
 
         /// <summary>
@@ -4385,7 +4387,6 @@ namespace TJAPlayer3
                     Dan_C[int.Parse(strCommandName.Substring(4)) - 1] = new Dan_C(examType, examValue, examRange);
                 }
             }
-
             if (this.nScoreModeTmp == 99) //2017.01.28 DD SCOREMODEを入力していない場合のみConfigで設定したモードにする
             {
                 this.nScoreModeTmp = TJAPlayer3.ConfigIni.nScoreMode;
@@ -4650,6 +4651,33 @@ namespace TJAPlayer3
                     }
                 }
             }
+            else if (strCommandName.Equals("GAUGEINCR"))
+            {
+                if (!string.IsNullOrEmpty(strCommandParam))
+                {
+                    switch (strCommandParam.ToLower())
+                    {
+                        case "normal":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Normal;
+                            break;
+                        case "floor":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Floor;
+                            break;
+                        case "round":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Round;
+                            break;
+                        case "ceiling":
+                            GaugeIncreaseMode = GaugeIncreaseMode.Ceiling;
+                            break;
+                        case "notfix":
+                            GaugeIncreaseMode = GaugeIncreaseMode.NotFix;
+                            break;
+                        default:
+                            GaugeIncreaseMode = GaugeIncreaseMode.Normal;
+                            break;
+                    }
+                }
+            }
             else if (strCommandName.Equals("SCOREDIFF"))
             {
                 ParseOptionalInt16(value => this.nScoreDiff[this.n参照中の難易度] = value);
@@ -4784,33 +4812,6 @@ namespace TJAPlayer3
                 if (!string.IsNullOrEmpty(strCommandParam))
                 {
                     this.bHIDDENBRANCH = true;
-                }
-            }
-            else if (strCommandName.Equals("GAUGEINCR"))
-            {
-                if(!string.IsNullOrEmpty(strCommandParam))
-                {
-                    switch (strCommandParam)
-                    {
-                        case "normal":
-                            GaugeIncreaseMode = GaugeIncreaseMode.Normal;
-                            break;
-                        case "floor":
-                            GaugeIncreaseMode = GaugeIncreaseMode.Floor;
-                            break;
-                        case "round":
-                            GaugeIncreaseMode = GaugeIncreaseMode.Round;
-                            break;
-                        case "ceiling":
-                            GaugeIncreaseMode = GaugeIncreaseMode.Ceiling;
-                            break;
-                        case "notfix":
-                            GaugeIncreaseMode = GaugeIncreaseMode.NotFix;
-                            break;
-                        default:
-                            GaugeIncreaseMode = GaugeIncreaseMode.Normal;
-                            break;
-                    }
                 }
             }
             if (this.nScoreModeTmp == 99)

--- a/TJAPlayer3/Songs/GaugeIncreaseMode.cs
+++ b/TJAPlayer3/Songs/GaugeIncreaseMode.cs
@@ -1,0 +1,29 @@
+﻿namespace TJAPlayer3
+{
+    /// <summary>
+    /// ゲージ増加量の種類。
+    /// </summary>
+    public enum GaugeIncreaseMode
+    {
+        /// <summary>
+        /// 切り捨てる。Floorと同義。
+        /// </summary>
+        Normal,
+        /// <summary>
+        /// 切り捨てる。
+        /// </summary>
+        Floor,
+        /// <summary>
+        /// 四捨五入する。
+        /// </summary>
+        Round,
+        /// <summary>
+        /// 切り上げる。
+        /// </summary>
+        Ceiling,
+        /// <summary>
+        /// 丸め処理を行わない。
+        /// </summary>
+        NotFix
+    }
+}

--- a/TJAPlayer3/Stages/07.Game/CAct演奏ゲージ共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏ゲージ共通.cs
@@ -258,24 +258,83 @@ namespace TJAPlayer3
             //this.dbゲージ増加量[ 2 ] = CDTXMania.DTX.bチップがある.Branch ? ( -260.0 / CDTXMania.DTX.nノーツ数[ 0 ] ) : -260.0 / CDTXMania.DTX.nノーツ数[ 3 ];
 
             //2015.03.26 kairera0467 計算を初期化時にするよう修正。
-            this.dbゲージ増加量[ 0 ] = (float)Math.Truncate( this.dbゲージ増加量[ 0 ] * 10000.0f ) / 10000.0f;
-            this.dbゲージ増加量[ 1 ] = (float)Math.Truncate( this.dbゲージ増加量[ 1 ] * 10000.0f ) / 10000.0f;
-            this.dbゲージ増加量[ 2 ] = (float)Math.Truncate( this.dbゲージ増加量[ 2 ] * 10000.0f ) / 10000.0f;
 
-            for (int i = 0; i < 3; i++ )
+            #region ゲージの丸め処理
+            var increase = new float[] { dbゲージ増加量[0], dbゲージ増加量[1], dbゲージ増加量[2] };
+            var increaseBranch = new float[3, 3];
+            for (int i = 0; i < 3; i++)
             {
-                this.dbゲージ増加量_Branch[ i, 0 ] = (float)Math.Truncate( this.dbゲージ増加量_Branch[ i, 0 ] * 10000.0f ) / 10000.0f;
-                this.dbゲージ増加量_Branch[ i, 1 ] = (float)Math.Truncate( this.dbゲージ増加量_Branch[ i, 1 ] * 10000.0f ) / 10000.0f;
-                this.dbゲージ増加量_Branch[ i, 2 ] = (float)Math.Truncate( this.dbゲージ増加量_Branch[ i, 2 ] * 10000.0f ) / 10000.0f;
+                increaseBranch[i, 0] = dbゲージ増加量_Branch[i, 0];
+                increaseBranch[i, 1] = dbゲージ増加量_Branch[i, 1];
+                increaseBranch[i, 2] = dbゲージ増加量_Branch[i, 0];
+            }
+            switch (TJAPlayer3.DTX.GaugeIncreaseMode)
+            {
+                case GaugeIncreaseMode.Normal:
+                case GaugeIncreaseMode.Floor:
+                    // 切り捨て
+                    for (int i = 0; i < 3; i++)
+                    {
+                        increase[i] = (float)Math.Truncate(increase[i] * 10000.0f) / 10000.0f;
+                    }
+                    for (int i = 0; i < 3; i++)
+                    {
+                        increaseBranch[i, 0] = (float)Math.Truncate(increaseBranch[i, 0] * 10000.0f) / 10000.0f;
+                        increaseBranch[i, 1] = (float)Math.Truncate(increaseBranch[i, 1] * 10000.0f) / 10000.0f;
+                        increaseBranch[i, 2] = (float)Math.Truncate(increaseBranch[i, 2] * 10000.0f) / 10000.0f;
+                    }
+                    break;
+                case GaugeIncreaseMode.Round:
+                    // 四捨五入
+                    for (int i = 0; i < 3; i++)
+                    {
+                        increase[i] = (float)Math.Round(increase[i] * 10000.0f) / 10000.0f;
+                    }
+                    for (int i = 0; i < 3; i++)
+                    {
+                        increaseBranch[i, 0] = (float)Math.Round(increaseBranch[i, 0] * 10000.0f) / 10000.0f;
+                        increaseBranch[i, 1] = (float)Math.Round(increaseBranch[i, 1] * 10000.0f) / 10000.0f;
+                        increaseBranch[i, 2] = (float)Math.Round(increaseBranch[i, 2] * 10000.0f) / 10000.0f;
+                    }
+                    break;
+                case GaugeIncreaseMode.Ceiling:
+                    // 切り上げ
+                    for (int i = 0; i < 3; i++)
+                    {
+                        increase[i] = (float)Math.Ceiling(increase[i] * 10000.0f) / 10000.0f;
+                    }
+                    for (int i = 0; i < 3; i++)
+                    {
+                        increaseBranch[i, 0] = (float)Math.Ceiling(increaseBranch[i, 0] * 10000.0f) / 10000.0f;
+                        increaseBranch[i, 1] = (float)Math.Ceiling(increaseBranch[i, 1] * 10000.0f) / 10000.0f;
+                        increaseBranch[i, 2] = (float)Math.Ceiling(increaseBranch[i, 2] * 10000.0f) / 10000.0f;
+                    }
+                    break;
+                case GaugeIncreaseMode.NotFix:
+                default:
+                    // 丸めない
+                    break;
             }
 
-		}
+            for (int i = 0; i < 3; i++)
+            {
+                dbゲージ増加量[i] = increase[i];
+            }
+            for (int i = 0; i < 3; i++)
+            {
+                dbゲージ増加量_Branch[i, 0] = increaseBranch[i, 0];
+                dbゲージ増加量_Branch[i, 1] = increaseBranch[i, 1];
+                dbゲージ増加量_Branch[i, 2] = increaseBranch[i, 2];
+            }
 
-		#region [ DAMAGE ]
-#if true		// DAMAGELEVELTUNING
-		#region [ DAMAGELEVELTUNING ]
-		// ----------------------------------
-		public float[ , ] fDamageGaugeDelta = {			// #23625 2011.1.10 ickw_284: tuned damage/recover factors
+            #endregion
+        }
+
+        #region [ DAMAGE ]
+#if true       // DAMAGELEVELTUNING
+        #region [ DAMAGELEVELTUNING ]
+        // ----------------------------------
+        public float[ , ] fDamageGaugeDelta = {			// #23625 2011.1.10 ickw_284: tuned damage/recover factors
 			// drums,   guitar,  bass
 			{  0.004f,  0.006f,  0.006f,  0.004f },
 			{  0.002f,  0.003f,  0.003f,  0.002f },

--- a/TJAPlayer3/Stages/07.Game/CAct演奏ゲージ共通.cs
+++ b/TJAPlayer3/Stages/07.Game/CAct演奏ゲージ共通.cs
@@ -231,26 +231,37 @@ namespace TJAPlayer3
 
             }
 
-            int nGaugeRankValue = (int)( Math.Floor( 10000.0f / dbGaugeMaxComboValue ) );
-            int[] nGaugeRankValue_branch = new int[3];
-
-            for (int i = 0; i < 3; i++ )
+            double nGaugeRankValue = 0D;
+            double[] nGaugeRankValue_branch = new double[] { 0D, 0D, 0D };
+            if (TJAPlayer3.DTX.GaugeIncreaseMode == GaugeIncreaseMode.Normal)
             {
-                nGaugeRankValue_branch[i] = (int)( Math.Floor( 10000.0f / dbGaugeMaxComboValue_branch[i] ) );
+                nGaugeRankValue =  Math.Floor( 10000.0f / dbGaugeMaxComboValue);
+                for (int i = 0; i < 3; i++ )
+                {
+                    nGaugeRankValue_branch[i] = Math.Floor( 10000.0f / dbGaugeMaxComboValue_branch[i]);
+                }
+            }
+            else
+            {
+                nGaugeRankValue = 10000.0f / dbGaugeMaxComboValue;
+                for (int i = 0; i < 3; i++)
+                {
+                    nGaugeRankValue_branch[i] = 10000.0f / dbGaugeMaxComboValue_branch[i];
+                }
             }
 
             //ゲージ値計算
             //実機に近い計算
 
-            this.dbゲージ増加量[ 0 ] = nGaugeRankValue / 100.0f;
-            this.dbゲージ増加量[ 1 ] = ( nGaugeRankValue / 100.0f ) * 0.5f;
-            this.dbゲージ増加量[ 2 ] = ( nGaugeRankValue / 100.0f ) * dbDamageRate;
+            this.dbゲージ増加量[0] = (float)nGaugeRankValue / 100.0f;
+            this.dbゲージ増加量[1] = (float)(nGaugeRankValue / 100.0f) * 0.5f;
+            this.dbゲージ増加量[2] = (float)(nGaugeRankValue / 100.0f) * dbDamageRate;
 
             for (int i = 0; i < 3; i++ )
             {
-                this.dbゲージ増加量_Branch[ i, 0 ] = nGaugeRankValue_branch[i] / 100.0f;
-                this.dbゲージ増加量_Branch[ i, 1 ] = ( nGaugeRankValue_branch[i] / 100.0f ) * 0.5f;
-                this.dbゲージ増加量_Branch[ i, 2 ] = ( nGaugeRankValue_branch[i] / 100.0f ) * dbDamageRate;
+                this.dbゲージ増加量_Branch[i, 0] = (float)nGaugeRankValue_branch[i] / 100.0f;
+                this.dbゲージ増加量_Branch[i, 1] = (float)(nGaugeRankValue_branch[i] / 100.0f) * 0.5f;
+                this.dbゲージ増加量_Branch[i, 2] = (float)(nGaugeRankValue_branch[i] / 100.0f) * dbDamageRate;
             }
 
             //this.dbゲージ増加量[ 0 ] = CDTXMania.DTX.bチップがある.Branch ? ( 130.0 / CDTXMania.DTX.nノーツ数[ 0 ] ) : ( 130.0 / CDTXMania.DTX.nノーツ数[ 3 ] );
@@ -326,7 +337,6 @@ namespace TJAPlayer3
                 dbゲージ増加量_Branch[i, 1] = increaseBranch[i, 1];
                 dbゲージ増加量_Branch[i, 2] = increaseBranch[i, 2];
             }
-
             #endregion
         }
 

--- a/TJAPlayer3/TJAPlayer3.csproj
+++ b/TJAPlayer3/TJAPlayer3.csproj
@@ -155,6 +155,7 @@
     <Compile Include="Songs\C曲リストノードComparers\C曲リストノードComparerノード種別.cs" />
     <Compile Include="Songs\C曲リストノードComparers\C曲リストノードComparer絶対パス.cs" />
     <Compile Include="Songs\Dan-C.cs" />
+    <Compile Include="Songs\GaugeIncreaseMode.cs" />
     <Compile Include="Stages\01.StartUp\TextureLoader.cs" />
     <Compile Include="Stages\02.Title\CActScanningLoudness.cs" />
     <Compile Include="Stages\02.Title\CEnumSongs.cs" />


### PR DESCRIPTION
ゲージ増加量の計算方法を設定できるようにヘッダーを追加したものです。]
基本的に #297 の通りです。
NORMALとFLOORは同義、と書いてますが、実際にはNORMALでは本家のゲージ増加量再現のためのランク付けで挙動が異なります。